### PR TITLE
grpc interceptors

### DIFF
--- a/src/AxonIQ.AxonServer.Connector/AppendEventsTransaction.cs
+++ b/src/AxonIQ.AxonServer.Connector/AppendEventsTransaction.cs
@@ -29,9 +29,9 @@ public class AppendEventsTransaction : IAppendEventsTransaction
         if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
         {
             _logger.LogDebug("Committing transaction {TransactionId}", _transactionId.ToString("N"));
-            await _call.RequestStream.CompleteAsync();
+            await _call.RequestStream.CompleteAsync().ConfigureAwait(false);
         }
-        return await _call.ResponseAsync;
+        return await _call.ResponseAsync.ConfigureAwait(false);
     }
 
     public Task Rollback()

--- a/src/AxonIQ.AxonServer.Connector/AsyncDisposableAsyncEnumerable.cs
+++ b/src/AxonIQ.AxonServer.Connector/AsyncDisposableAsyncEnumerable.cs
@@ -36,8 +36,8 @@ internal class AsyncDisposableAsyncEnumerable<T> : IAsyncEnumerable<T>
 
         public async ValueTask DisposeAsync()
         {
-            await _enumerator.DisposeAsync();
-            await _disposable.DisposeAsync();
+            await _enumerator.DisposeAsync().ConfigureAwait(false);
+            await _disposable.DisposeAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnection.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnection.cs
@@ -114,7 +114,7 @@ public class AxonServerConnection : IAxonServerConnection
     {
         try
         {
-            while (await _inbox.Reader.WaitToReadAsync(ct))
+            while (await _inbox.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
             {
                 while (_inbox.Reader.TryRead(out var message))
                 {
@@ -125,7 +125,7 @@ public class AxonServerConnection : IAxonServerConnection
                             switch (CurrentState)
                             {
                                 case State.Disconnected:
-                                    var channel = await _channelFactory.Create(_context);
+                                    var channel = await _channelFactory.Create(_context).ConfigureAwait(false);
                                     if (channel != null)
                                     {
                                         var callInvoker = channel
@@ -140,7 +140,7 @@ public class AxonServerConnection : IAxonServerConnection
                                         //State needs to be set for the control channel to pick up
                                         //the right call invoker
                                         CurrentState = new State.Connected(channel, callInvoker);
-                                        await _controlChannel.Connect();
+                                        await _controlChannel.Connect().ConfigureAwait(false);
                                     }
                                     else
                                     {
@@ -162,18 +162,19 @@ public class AxonServerConnection : IAxonServerConnection
                             switch (CurrentState)
                             {
                                 case State.Connected connected:
-                                    await _controlChannel.Reconnect();
+                                    await _controlChannel.Reconnect().ConfigureAwait(false);
 
                                     _logger.LogInformation(
                                         "Reconnect for context {Context} requested. Closing current connection",
                                         _context);
-                                    await connected.Channel.ShutdownAsync();
+                                    await connected.Channel.ShutdownAsync().ConfigureAwait(false);
                                     connected.Channel.Dispose();
 
                                     CurrentState = new State.Disconnected();
 
                                     await _scheduler.ScheduleTask(
-                                        () => _inbox.Writer.WriteAsync(new Protocol.Connect(), ct), _scheduler.Clock());
+                                        () => _inbox.Writer.WriteAsync(new Protocol.Connect(), ct), _scheduler.Clock()
+                                    ).ConfigureAwait(false);
                                     break;
                             }
 
@@ -199,7 +200,7 @@ public class AxonServerConnection : IAxonServerConnection
     {
         await _inbox.Writer.WriteAsync(
             new Protocol.Connect()
-        );
+        ).ConfigureAwait(false);
     }
 
     public Task WaitUntilConnected()
@@ -296,11 +297,11 @@ public class AxonServerConnection : IAxonServerConnection
     {
         _inboxCancellation.Cancel();
         _inbox.Writer.Complete();
-        await _inbox.Reader.Completion;
-        await _protocol;
+        await _inbox.Reader.Completion.ConfigureAwait(false);
+        await _protocol.ConfigureAwait(false);
         _controlChannel.Connected -= _onConnectedHandler;
         _controlChannel.HeartbeatMissed -= _onHeartbeatMissedHandler;
-        await _controlChannel.DisposeAsync();
+        await _controlChannel.DisposeAsync().ConfigureAwait(false);
         _inboxCancellation.Dispose();
         _protocol.Dispose();
     }

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnectionFactory.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnectionFactory.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net;
+using Grpc.Core.Interceptors;
+using Grpc.Net.Client;
 using Microsoft.Extensions.Logging;
 
 namespace AxonIQ.AxonServer.Connector;
@@ -11,6 +13,7 @@ public class AxonServerConnectionFactory
     private readonly ConcurrentDictionary<Context, Lazy<AxonServerConnection>> _connections;
     private readonly PermitCount _commandPermits;
     private readonly PermitCount _queryPermits;
+    private readonly IReadOnlyList<Interceptor> _interceptors;
 
     public AxonServerConnectionFactory(AxonServerConnectionFactoryOptions options)
     {
@@ -33,9 +36,11 @@ public class AxonServerConnectionFactory
                 ClientIdentity, 
                 Authentication, 
                 RoutingServers, 
-                options.LoggerFactory,
-                options.GrpcChannelOptions);
+                options.LoggerFactory, 
+                options.Interceptors,
+                options.GrpcChannelOptions ?? new GrpcChannelOptions());
 
+        _interceptors = options.Interceptors;
         _commandPermits = options.CommandPermits;
         _queryPermits = options.QueryPermits;
 
@@ -50,7 +55,7 @@ public class AxonServerConnectionFactory
     public async Task<IAxonServerConnection> Connect(Context context)
     {
         var connection = _connections.GetOrAdd(context,
-            _ => new Lazy<AxonServerConnection>(() => new AxonServerConnection(context, _channelFactory, _scheduler, _commandPermits, _queryPermits, LoggerFactory)))
+            _ => new Lazy<AxonServerConnection>(() => new AxonServerConnection(context, _channelFactory, _interceptors, _scheduler, _commandPermits, _queryPermits, LoggerFactory)))
             .Value;
         await connection.Connect();
         return connection;

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnectionFactory.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnectionFactory.cs
@@ -57,7 +57,7 @@ public class AxonServerConnectionFactory
         var connection = _connections.GetOrAdd(context,
             _ => new Lazy<AxonServerConnection>(() => new AxonServerConnection(context, _channelFactory, _interceptors, _scheduler, _commandPermits, _queryPermits, LoggerFactory)))
             .Value;
-        await connection.Connect();
+        await connection.Connect().ConfigureAwait(false);
         return connection;
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/CommandHandlerRegistration.cs
+++ b/src/AxonIQ.AxonServer.Connector/CommandHandlerRegistration.cs
@@ -19,7 +19,7 @@ public class CommandHandlerRegistration : ICommandHandlerRegistration
     {
         if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
         {
-            await _unsubscribe();
+            await _unsubscribe().ConfigureAwait(false);
         }    
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/ControlChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/ControlChannel.cs
@@ -197,7 +197,7 @@ public class ControlChannel : IControlChannel, IAsyncDisposable
                             switch (CurrentState)
                             {
                                 case State.Connected connected:
-                                    await connected.InstructionStream!.RequestStream.WriteAsync(send.Instruction);
+                                    await connected.InstructionStream!.RequestStream.WriteAsync(send.Instruction, ct);
                                     send.CompletionSource.SetResult();
                                     break;
                                 case State.Disconnected:

--- a/src/AxonIQ.AxonServer.Connector/EventChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/EventChannel.cs
@@ -51,7 +51,7 @@ public class EventChannel : IEventChannel
             Event = @event
         };
         using var call = EventScheduler.ScheduleEventAsync(request);
-        var response = await call.ResponseAsync;
+        var response = await call.ResponseAsync.ConfigureAwait(false);
         return new ScheduledEventCancellationToken(response.Token);
     }
 
@@ -62,7 +62,7 @@ public class EventChannel : IEventChannel
             Token = token.ToString()
         };
         using var call = EventScheduler.CancelScheduledEventAsync(request);
-        return await call.ResponseAsync;
+        return await call.ResponseAsync.ConfigureAwait(false);
     }
 
     public Task<ScheduledEventCancellationToken> Reschedule(ScheduledEventCancellationToken token, Duration duration, Event @event)
@@ -79,7 +79,7 @@ public class EventChannel : IEventChannel
             Token = token.ToString()
         };
         using var call = EventScheduler.RescheduleEventAsync(request);
-        var response = await call.ResponseAsync;
+        var response = await call.ResponseAsync.ConfigureAwait(false);
         return new ScheduledEventCancellationToken(response.Token);
     }
 
@@ -87,7 +87,7 @@ public class EventChannel : IEventChannel
     {
         var request = new ReadHighestSequenceNrRequest{ AggregateId = id.ToString() };
         using var call = EventStore.ReadHighestSequenceNrAsync(request);
-        var response = await call.ResponseAsync;
+        var response = await call.ResponseAsync.ConfigureAwait(false);
         return new EventSequenceNumber(response.ToSequenceNr);
     }
 
@@ -101,7 +101,7 @@ public class EventChannel : IEventChannel
             ForceReadFromLeader = forceReadFromLeader,
             TrackingToken = token.ToInt64() + 1L,
             NumberOfPermits = initial.ToInt64()
-        });
+        }).ConfigureAwait(false);
         return new EventStream(initial, threshold, call, _loggerFactory);
     }
 
@@ -132,7 +132,7 @@ public class EventChannel : IEventChannel
     {
         if (snapshot == null) throw new ArgumentNullException(nameof(snapshot));
         using var call = EventStore.AppendSnapshotAsync(snapshot);
-        return await call.ResponseAsync;
+        return await call.ResponseAsync.ConfigureAwait(false);
     }
 
     public IAggregateEventStream LoadSnapshots(AggregateId id, EventSequenceNumber? from = default, EventSequenceNumber? to = default,
@@ -153,7 +153,7 @@ public class EventChannel : IEventChannel
     {
         var request = new GetLastTokenRequest();
         using var call = EventStore.GetLastTokenAsync(request);
-        var token = await call.ResponseAsync;
+        var token = await call.ResponseAsync.ConfigureAwait(false);
         return new EventStreamToken(Math.Max(token.Token, 0L) - 1L);
     }
 
@@ -161,7 +161,7 @@ public class EventChannel : IEventChannel
     {
         var request = new GetFirstTokenRequest();
         using var call = EventStore.GetFirstTokenAsync(request);
-        var token = await call.ResponseAsync;
+        var token = await call.ResponseAsync.ConfigureAwait(false);
         return new EventStreamToken(Math.Max(token.Token, 0L) - 1L);
     }
 
@@ -172,7 +172,7 @@ public class EventChannel : IEventChannel
             Instant = instant
         };
         using var call = EventStore.GetTokenAtAsync(request);
-        var response = await call.ResponseAsync;
+        var response = await call.ResponseAsync.ConfigureAwait(false);
         return new EventStreamToken(Math.Max(response.Token, 0L) - 1L);
     }
 

--- a/src/AxonIQ.AxonServer.Connector/EventChannelExtensions.cs
+++ b/src/AxonIQ.AxonServer.Connector/EventChannelExtensions.cs
@@ -7,7 +7,7 @@ public static class EventChannelExtensions
     public static async Task<Confirmation> AppendEvents(this IEventChannel channel, params Event[] events)
     {
         var transaction = channel.StartAppendEventsTransaction();
-        foreach (var @event in events) await transaction.AppendEventAsync(@event);
-        return await transaction.CommitAsync();
+        foreach (var @event in events) await transaction.AppendEventAsync(@event).ConfigureAwait(false);
+        return await transaction.CommitAsync().ConfigureAwait(false);
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/FlowControlAwareAsyncEnumerator.cs
+++ b/src/AxonIQ.AxonServer.Connector/FlowControlAwareAsyncEnumerator.cs
@@ -28,12 +28,12 @@ public class FlowControlAwareAsyncEnumerator<TRequest, TResponse> : IAsyncEnumer
 
     public async ValueTask<bool> MoveNextAsync()
     {
-        var move = _enumerator.MoveNextAsync();
+        var move = _enumerator.MoveNextAsync().ConfigureAwait(false);
         if (_controller.Increment())
         {
             var request = _builder();
             _logger.LogDebug("Sending request for data {Request}", request);
-            await _writer.WriteAsync(request);
+            await _writer.WriteAsync(request).ConfigureAwait(false);
         }
         return await move;
     }

--- a/src/AxonIQ.AxonServer.Connector/HeartbeatChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/HeartbeatChannel.cs
@@ -60,7 +60,7 @@ public class HeartbeatChannel : IAsyncDisposable
         var all = new HashSet<SentHeartbeat>();
         try
         {
-            while (await _inbox.Reader.WaitToReadAsync(ct))
+            while (await _inbox.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
             {
                 while (_inbox.Reader.TryRead(out var message))
                 {
@@ -88,7 +88,7 @@ public class HeartbeatChannel : IAsyncDisposable
                             {
                                 InstructionId = id,
                                 Heartbeat = HeartbeatInstance
-                            });
+                            }).ConfigureAwait(false);
                             break;
                         case Protocol.Purge purge:
                             var overdue = all.RemoveWhere(candidate => candidate.Due < purge.Due);
@@ -121,7 +121,7 @@ public class HeartbeatChannel : IAsyncDisposable
                                     .ToArray();
                             foreach (var heartbeat in heartbeats)
                             {
-                                await heartbeat.Responder(receive.Message);
+                                await heartbeat.Responder(receive.Message).ConfigureAwait(false);
                             }
 
                             all.ExceptWith(heartbeats);
@@ -180,9 +180,9 @@ public class HeartbeatChannel : IAsyncDisposable
     {
         _inboxCancellation.Cancel();
         _inbox.Writer.Complete();
-        await _inbox.Reader.Completion;
-        await _protocol;
-        await _timer.DisposeAsync();
+        await _inbox.Reader.Completion.ConfigureAwait(false);
+        await _protocol.ConfigureAwait(false);
+        await _timer.DisposeAsync().ConfigureAwait(false);
         _inboxCancellation.Dispose();
         _protocol.Dispose();
     }

--- a/src/AxonIQ.AxonServer.Connector/HeartbeatMonitor.cs
+++ b/src/AxonIQ.AxonServer.Connector/HeartbeatMonitor.cs
@@ -66,7 +66,7 @@ public class HeartbeatMonitor : IAsyncDisposable
         try
         {
             State state = new State.Disabled(_leaderClock.LogicalTime);
-            while (!ct.IsCancellationRequested && await _inbox.Reader.WaitToReadAsync(ct))
+            while (!ct.IsCancellationRequested && await _inbox.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
             {
                 while (_inbox.Reader.TryRead(out var message))
                 {
@@ -116,7 +116,7 @@ public class HeartbeatMonitor : IAsyncDisposable
                                                     new Protocol.CheckSucceeded(enabled.LogicalTime), ct)
                                                 : _inbox.Writer.WriteAsync(
                                                     new Protocol.CheckFailed(ack.Error, enabled.LogicalTime), ct),
-                                            enabled.Timeout);
+                                            enabled.Timeout).ConfigureAwait(false);
                                         enabled = enabled with
                                         {
                                             NextHeartbeatCheckAt = wallTime.Add(enabled.Interval)
@@ -389,7 +389,7 @@ public class HeartbeatMonitor : IAsyncDisposable
                 timeout,
                 _leaderClock.Next()
             )
-        );
+        ).ConfigureAwait(false);
     }
     
     public async Task Disable()
@@ -398,7 +398,7 @@ public class HeartbeatMonitor : IAsyncDisposable
             new Protocol.Disable(
                 _leaderClock.Next()
             )
-        );
+        ).ConfigureAwait(false);
     }
     
     public async Task Pause()
@@ -407,7 +407,7 @@ public class HeartbeatMonitor : IAsyncDisposable
             new Protocol.Pause(
                 _leaderClock.Next()
             )
-        );
+        ).ConfigureAwait(false);
     }
     
     public async Task Resume()
@@ -416,7 +416,7 @@ public class HeartbeatMonitor : IAsyncDisposable
             new Protocol.Resume(
                 _leaderClock.Next()
             )
-        );
+        ).ConfigureAwait(false);
     }
 
     public async Task ReceiveServerHeartbeat()
@@ -425,7 +425,7 @@ public class HeartbeatMonitor : IAsyncDisposable
             new Protocol.ReceiveServerHeartbeat(
                 _leaderClock.LogicalTime
             )
-        );
+        ).ConfigureAwait(false);
     }
     
     public event EventHandler? HeartbeatMissed;
@@ -439,9 +439,9 @@ public class HeartbeatMonitor : IAsyncDisposable
     {
         _inboxCancellation.Cancel();
         _inbox.Writer.Complete();
-        await _inbox.Reader.Completion;
-        await _protocol;
-        await _timer.DisposeAsync();
+        await _inbox.Reader.Completion.ConfigureAwait(false);
+        await _protocol.ConfigureAwait(false);
+        await _timer.DisposeAsync().ConfigureAwait(false);
         _inboxCancellation.Dispose();
         _protocol.Dispose();
     }

--- a/src/AxonIQ.AxonServer.Connector/IAxonServerConnectionFactoryOptionsBuilder.cs
+++ b/src/AxonIQ.AxonServer.Connector/IAxonServerConnectionFactoryOptionsBuilder.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
 using Microsoft.Extensions.Logging;
 
@@ -19,6 +20,7 @@ public interface IAxonServerConnectionFactoryOptionsBuilder
     IAxonServerConnectionFactoryOptionsBuilder WithLoggerFactory(ILoggerFactory loggerFactory);
     IAxonServerConnectionFactoryOptionsBuilder WithClock(Func<DateTimeOffset> clock);
     IAxonServerConnectionFactoryOptionsBuilder WithGrpcChannelOptions(GrpcChannelOptions grpcChannelOptions);
+    IAxonServerConnectionFactoryOptionsBuilder WithInterceptors(params Interceptor[] interceptors);
     IAxonServerConnectionFactoryOptionsBuilder WithCommandPermits(PermitCount count);
     IAxonServerConnectionFactoryOptionsBuilder WithQueryPermits(PermitCount count);
 

--- a/src/AxonIQ.AxonServer.Connector/IQueryResponseChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/IQueryResponseChannel.cs
@@ -10,11 +10,11 @@ public interface IQueryResponseChannel
     {
         try
         {
-            await SendAsync(response);
+            await SendAsync(response).ConfigureAwait(false);
         }
         finally
         {
-            await CompleteAsync();
+            await CompleteAsync().ConfigureAwait(false);
         }
     }
     ValueTask CompleteAsync();

--- a/src/AxonIQ.AxonServer.Connector/QueryHandlerRegistration.cs
+++ b/src/AxonIQ.AxonServer.Connector/QueryHandlerRegistration.cs
@@ -19,7 +19,7 @@ public class QueryHandlerRegistration : IQueryHandlerRegistration
     {
         if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
         {
-            await _unsubscribe();
+            await _unsubscribe().ConfigureAwait(false);
         }    
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/QueryResponseChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/QueryResponseChannel.cs
@@ -48,7 +48,7 @@ public class QueryResponseChannel : IQueryResponseChannel
                 MessageIdentifier = instructionId1
             },
             InstructionId = instructionId1
-        });
+        }).ConfigureAwait(false);
         
         var instructionId2 = InstructionId.New().ToString();
         await _writer(new QueryProviderOutbound
@@ -59,7 +59,7 @@ public class QueryResponseChannel : IQueryResponseChannel
                 MessageId = instructionId2
             },
             InstructionId = instructionId2
-        });
+        }).ConfigureAwait(false);
     }
 
     public async ValueTask CompleteWithErrorAsync(ErrorCategory errorCategory, ErrorMessage errorMessage)
@@ -74,7 +74,7 @@ public class QueryResponseChannel : IQueryResponseChannel
                 MessageIdentifier = instructionId1
             },
             InstructionId = instructionId1
-        });
+        }).ConfigureAwait(false);
         
         var instructionId2 = InstructionId.New().ToString();
         await _writer(new QueryProviderOutbound
@@ -85,6 +85,6 @@ public class QueryResponseChannel : IQueryResponseChannel
                 MessageId = instructionId2
             },
             InstructionId = instructionId2
-        });
+        }).ConfigureAwait(false);
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/QueryResponseConsumerStream.cs
+++ b/src/AxonIQ.AxonServer.Connector/QueryResponseConsumerStream.cs
@@ -39,7 +39,7 @@ internal class QueryResponseConsumerStream : IAsyncEnumerable<QueryResponse>
 
         public async ValueTask DisposeAsync()
         {
-            await _enumerator.DisposeAsync();
+            await _enumerator.DisposeAsync().ConfigureAwait(false);
             _disposable.Dispose();
         }
     }

--- a/src/AxonIQ.AxonServer.Connector/QuerySubscriptionResult.cs
+++ b/src/AxonIQ.AxonServer.Connector/QuerySubscriptionResult.cs
@@ -57,7 +57,7 @@ public class QuerySubscriptionResult : IQuerySubscriptionResult
     {
         try
         {
-            await foreach (var response in reader.ReadAllAsync(cancellationToken: ct))
+            await foreach (var response in reader.ReadAllAsync(cancellationToken: ct).ConfigureAwait(false))
             {
                 switch (response.ResponseCase)
                 {
@@ -71,7 +71,7 @@ public class QuerySubscriptionResult : IQuerySubscriptionResult
                         _logger.LogDebug("Received subscription query update. Subscription Id: {SubscriptionId}. Message Id: {MessageId}",
                             response.SubscriptionIdentifier,
                             response.MessageIdentifier);
-                        await _updateChannel.Writer.WriteAsync(response.Update, ct);
+                        await _updateChannel.Writer.WriteAsync(response.Update, ct).ConfigureAwait(false);
                         break;
                     case SubscriptionQueryResponse.ResponseOneofCase.Complete:
                         _logger.LogDebug("Received subscription query complete. Subscription Id: {SubscriptionId}",
@@ -129,7 +129,7 @@ public class QuerySubscriptionResult : IQuerySubscriptionResult
                     QueryRequest = _request,
                     SubscriptionIdentifier = _request.MessageIdentifier
                 }
-            });
+            }).ConfigureAwait(false);
         }
 
         return await _initialResult;
@@ -142,7 +142,7 @@ public class QuerySubscriptionResult : IQuerySubscriptionResult
     public async ValueTask DisposeAsync()
     {
         _call.Dispose();
-        await _consumer;
+        await _consumer.ConfigureAwait(false);
         _initialResultSource.TrySetCanceled();
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/SubscriptionQueryInitialResultResponseChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/SubscriptionQueryInitialResultResponseChannel.cs
@@ -54,7 +54,7 @@ public class SubscriptionQueryInitialResultResponseChannel : IQueryResponseChann
                 MessageIdentifier = instructionId1
             },
             InstructionId = instructionId1
-        });
+        }).ConfigureAwait(false);
         
         var instructionId2 = InstructionId.New().ToString();
         await _writer(new QueryProviderOutbound
@@ -65,7 +65,7 @@ public class SubscriptionQueryInitialResultResponseChannel : IQueryResponseChann
                 MessageId = instructionId2
             },
             InstructionId = instructionId2
-        });
+        }).ConfigureAwait(false);
     }
 
     public async ValueTask CompleteWithErrorAsync(ErrorCategory errorCategory, ErrorMessage errorMessage)
@@ -80,7 +80,7 @@ public class SubscriptionQueryInitialResultResponseChannel : IQueryResponseChann
                 MessageIdentifier = instructionId1
             },
             InstructionId = instructionId1
-        });
+        }).ConfigureAwait(false);
         
         var instructionId2 = InstructionId.New().ToString();
         await _writer(new QueryProviderOutbound
@@ -91,6 +91,6 @@ public class SubscriptionQueryInitialResultResponseChannel : IQueryResponseChann
                 MessageId = instructionId2
             },
             InstructionId = instructionId2
-        });
+        }).ConfigureAwait(false);
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/SubscriptionQueryRegistration.cs
+++ b/src/AxonIQ.AxonServer.Connector/SubscriptionQueryRegistration.cs
@@ -19,7 +19,7 @@ public class SubscriptionQueryRegistration : ISubscriptionQueryRegistration
     {
         if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
         {
-            await _unsubscribe();
+            await _unsubscribe().ConfigureAwait(false);
         }    
     }
 }

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryOptionsTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryOptionsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using AutoFixture;
+using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
@@ -428,6 +429,7 @@ public class AxonServerConnectionFactoryOptionsTests
         Assert.Same(AxonServerAuthentication.None, result.Authentication);
         Assert.IsType<NullLoggerFactory>(result.LoggerFactory);
         Assert.Null(result.GrpcChannelOptions);
+        Assert.Empty(result.Interceptors);
     }
 
     [Fact]
@@ -459,6 +461,7 @@ public class AxonServerConnectionFactoryOptionsTests
         Assert.Same(AxonServerAuthentication.None, result.Authentication);
         Assert.IsType<NullLoggerFactory>(result.LoggerFactory);
         Assert.Null(result.GrpcChannelOptions);
+        Assert.Empty(result.Interceptors);
     }
 
     [Fact]
@@ -518,5 +521,39 @@ public class AxonServerConnectionFactoryOptionsTests
         
         Assert.Null(result.GrpcChannelOptions);
     }
+    
+    [Fact]
+    public void WithInterceptorsCanNotBeNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => CreateSystemUnderTest().WithInterceptors(null!));
+    }
+
+    [Fact]
+    public void WithInterceptorsReturnsExpectedResult()
+    {
+        var component = _fixture.Create<ComponentName>();
+        var clientInstance = _fixture.Create<ClientInstanceId>();
+        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var interceptors = new Interceptor[]
+        {
+            new FakeInterceptor()
+        };
+        var result = sut.WithInterceptors(interceptors).Build();
+        
+        Assert.Equal(interceptors, result.Interceptors);
+    }
+    
+    [Fact]
+    public void WithoutInterceptorsReturnsExpectedResult()
+    {
+        var component = _fixture.Create<ComponentName>();
+        var clientInstance = _fixture.Create<ClientInstanceId>();
+        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var result = sut.Build();
+        
+        Assert.Empty(result.Interceptors);
+    }
     //TODO: Extend with tests that cover obtaining all other options from configuration
+    
+    private class FakeInterceptor : Interceptor { }
 }

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerGrpcChannelFactoryTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerGrpcChannelFactoryTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using AutoFixture;
 using AxonIQ.AxonServer.Connector.Tests.Containerization;
 using AxonIQ.AxonServer.Connector.Tests.Framework;
+using Grpc.Core.Interceptors;
+using Grpc.Net.Client;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,8 +38,9 @@ public class AxonServerGrpcChannelFactoryTests
                 clientIdentity, 
                 AxonServerAuthentication.None,
                 routingServers, 
-                _loggerFactory,
-                null);
+                _loggerFactory, 
+                Array.Empty<Interceptor>(),
+                new GrpcChannelOptions());
 
             var result = await sut.Create(context);
 
@@ -67,7 +70,7 @@ public class AxonServerGrpcChannelFactoryTests
         {
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
-                routingServers, _loggerFactory, null);
+                routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions());
         }
 
         [Fact]
@@ -123,14 +126,14 @@ public class AxonServerGrpcChannelFactoryTests
         {
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
-                routingServers, _loggerFactory, null);
+                routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions());
         }
         
         private AxonServerGrpcChannelFactory CreateSystemUnderTest(IReadOnlyList<DnsEndPoint> routingServers, IAxonServerAuthentication authentication)
         {
             var clientIdentity = _fixture.Create<ClientIdentity>();
-            return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory,
-                null);
+            return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory, Array.Empty<Interceptor>(),
+                new GrpcChannelOptions());
         }
         
         [Fact]
@@ -218,7 +221,7 @@ public class AxonServerGrpcChannelFactoryTests
         {
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
-                routingServers, _loggerFactory, null);
+                routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions());
         }
 
         [Fact]
@@ -276,14 +279,14 @@ public class AxonServerGrpcChannelFactoryTests
         {
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
-                routingServers, _loggerFactory, null);
+                routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions());
         }
         
         private AxonServerGrpcChannelFactory CreateSystemUnderTest(IReadOnlyList<DnsEndPoint> routingServers, IAxonServerAuthentication authentication)
         {
             var clientIdentity = _fixture.Create<ClientIdentity>();
-            return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory,
-                null);
+            return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory, Array.Empty<Interceptor>(),
+                new GrpcChannelOptions());
         }
 
         [Fact]
@@ -505,7 +508,7 @@ public class AxonServerGrpcChannelFactoryTests
                 var routingServers = cluster.GetGrpcEndpoints();
                 var sut = new AxonServerGrpcChannelFactory(clientIdentity,
                     AxonServerAuthentication.UsingToken(template.Applications![0].Token!),
-                    routingServers, _loggerFactory, null);
+                    routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions());
 
                 var result = await sut.Create(context);
 

--- a/test/AxonIQ.AxonServer.Connector.Tests/ContextTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/ContextTests.cs
@@ -1,6 +1,8 @@
 using AutoFixture;
 using AutoFixture.Idioms;
 using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Grpc.Net.Client;
 using Xunit;
 
 namespace AxonIQ.AxonServer.Connector.Tests;

--- a/test/AxonIQ.AxonServer.Connector.Tests/ControlChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/ControlChannelIntegrationTests.cs
@@ -1,9 +1,12 @@
 using AutoFixture;
 using AxonIQ.AxonServer.Connector.Tests.Containerization;
+using AxonIQ.AxonServer.Connector.Tests.Framework;
+using AxonIQ.AxonServer.Connector.Tests.Interceptors;
 using Io.Axoniq.Axonserver.Grpc.Control;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace AxonIQ.AxonServer.Connector.Tests;
 
@@ -14,13 +17,13 @@ public class ControlChannelIntegrationTests
     private readonly Fixture _fixture;
     private readonly ILoggerFactory _loggerFactory;
 
-    public ControlChannelIntegrationTests(AxonServerWithAccessControlDisabled container)
+    public ControlChannelIntegrationTests(AxonServerWithAccessControlDisabled container, ITestOutputHelper output)
     {
         _container = container ?? throw new ArgumentNullException(nameof(container));
         _fixture = new Fixture();
         _fixture.CustomizeClientInstanceId();
         _fixture.CustomizeComponentName();
-        _loggerFactory = new NullLoggerFactory();
+        _loggerFactory = new TestOutputHelperLoggerFactory(output);
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
@@ -30,7 +33,8 @@ public class ControlChannelIntegrationTests
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
         var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
-            .WithRoutingServers(_container.GetGrpcEndpoint());
+            .WithRoutingServers(_container.GetGrpcEndpoint())
+            .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);
         var options = builder.Build();
         var factory = new AxonServerConnectionFactory(options);
@@ -44,5 +48,52 @@ public class ControlChannelIntegrationTests
         var sut = connection.ControlChannel;
         var result = sut.SendInstruction(new PlatformInboundInstruction());
         Assert.True(result.IsCompleted);
+    }
+    
+    [Fact]
+    public async Task RecoveryAfterMissedHeartbeat()
+    {
+        var interceptor = new ControlledAvailabilityInterceptor();
+
+        var connection = await CreateSystemUnderTest(options => options.WithInterceptors(interceptor));
+        var sut = connection.ControlChannel;
+        await connection.WaitUntilReady();
+        
+        await sut.EnableHeartbeat(TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(500));
+        // Allow the heartbeat pump to start
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        
+        Assert.True(connection.IsConnected);
+        Assert.True(connection.IsReady);
+        
+        // Observe a disconnect
+        var disconnected = new TaskCompletionSource();
+        connection.Disconnected += (_, _) =>
+        {
+            disconnected.TrySetResult();
+        };
+        
+        //Simulate unavailability
+        interceptor.Available = false;
+        
+        //Wait for the disconnect to be observed
+        await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(connection.IsConnected);
+        Assert.False(connection.IsReady);
+        
+        //Observe a connect
+        var connected = new TaskCompletionSource();
+        connection.Connected += (_, _) =>
+        {
+            connected.TrySetResult();
+        };
+        
+        //Simulate availability
+        interceptor.Available = true;
+        
+        //Wait for the connect to be observed
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(connection.IsConnected);
+        Assert.True(connection.IsReady);
     }
 }

--- a/test/AxonIQ.AxonServer.Connector.Tests/FixtureExtensions.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/FixtureExtensions.cs
@@ -72,7 +72,7 @@ public static class FixtureExtensions
     public static void CustomizeLocalHostDnsEndPointInReservedPortRange(this IFixture fixture)
     {
         // REMARK: Due to the randomization of data we might accidentally pick a port on which an AxonServer is listening.
-        // By s no Axon Server will be listening on a host and port in the reserved port range [0..1024], we prevent this
+        // Since no Axon Server will be listening on a host and port in the reserved port range [0..1024], we prevent this
         // accident from happening.
         fixture.Customize<DnsEndPoint>(composer =>
             composer

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ConditionalAvailabilityAsyncStreamReader.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ConditionalAvailabilityAsyncStreamReader.cs
@@ -1,0 +1,27 @@
+using Grpc.Core;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+internal class ConditionalAvailabilityAsyncStreamReader<TResponse> : IAsyncStreamReader<TResponse>
+{
+    private readonly IAsyncStreamReader<TResponse> _reader;
+    private readonly Predicate<object?> _available;
+
+    public ConditionalAvailabilityAsyncStreamReader(IAsyncStreamReader<TResponse> reader, Predicate<object?> available)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _available = available ?? throw new ArgumentNullException(nameof(available));
+    }
+        
+    public async Task<bool> MoveNext(CancellationToken cancellationToken)
+    {
+        var moved = await _reader.MoveNext(cancellationToken);
+        if (moved && !_available(_reader.Current))
+        {
+            throw new RpcException(new Status(StatusCode.Unavailable, ""));
+        }
+        return moved;
+    }
+
+    public TResponse Current => !_available(_reader.Current) ? throw new RpcException(new Status(StatusCode.Unavailable, "")) : _reader.Current;
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ConditionalAvailabilityClientAsyncStreamWriter.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ConditionalAvailabilityClientAsyncStreamWriter.cs
@@ -1,0 +1,34 @@
+using Grpc.Core;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+internal class ConditionalAvailabilityClientAsyncStreamWriter<TRequest> : IClientStreamWriter<TRequest>
+{
+    private readonly IClientStreamWriter<TRequest> _writer;
+    private readonly Predicate<object?> _available;
+
+    public ConditionalAvailabilityClientAsyncStreamWriter(IClientStreamWriter<TRequest> writer, Predicate<object?> available)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _available = available ?? throw new ArgumentNullException(nameof(available));
+    }
+    public Task WriteAsync(TRequest message)
+    {
+        if (!_available(message))
+        {
+            throw new RpcException(new Status(StatusCode.Unavailable, ""));
+        }
+        return _writer.WriteAsync(message);
+    }
+
+    public WriteOptions? WriteOptions
+    {
+        get => _writer.WriteOptions;
+        set => _writer.WriteOptions = value;
+    }
+    
+    public Task CompleteAsync()
+    {
+        return _writer.CompleteAsync();
+    }
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ConditionalAvailabilityInterceptor.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ConditionalAvailabilityInterceptor.cs
@@ -1,0 +1,77 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+public class ConditionalAvailabilityInterceptor<TRequestMessage, TResponseMessage> : Interceptor
+{
+    private readonly Predicate<TRequestMessage> _availableForRequestStreamMessage;
+    private readonly Predicate<TResponseMessage> _availableForResponseStreamMessage;
+
+    public ConditionalAvailabilityInterceptor(Predicate<TRequestMessage> availableForRequestStreamMessage, Predicate<TResponseMessage> availableForResponseStreamMessage)
+    {
+        _availableForRequestStreamMessage = availableForRequestStreamMessage ?? throw new ArgumentNullException(nameof(availableForRequestStreamMessage));
+        _availableForResponseStreamMessage = availableForResponseStreamMessage ?? throw new ArgumentNullException(nameof(availableForResponseStreamMessage));
+    }
+
+    public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(context);
+        var requestStream =
+            typeof(TRequest) == typeof(TRequestMessage)
+                ? new ConditionalAvailabilityClientAsyncStreamWriter<TRequest>(call.RequestStream,
+                    message => !ReferenceEquals(message, null) && _availableForRequestStreamMessage((TRequestMessage)message))
+                : call.RequestStream;
+        return new AsyncClientStreamingCall<TRequest, TResponse>(
+            requestStream,
+            call.ResponseAsync,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose
+        );
+    }
+
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context, AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(request, context);
+        var responseStream =
+            typeof(TResponse) == typeof(TResponseMessage)
+                ? new ConditionalAvailabilityAsyncStreamReader<TResponse>(call.ResponseStream,
+                    message => !ReferenceEquals(message, null) && _availableForResponseStreamMessage((TResponseMessage)message))
+                : call.ResponseStream;
+        return new AsyncServerStreamingCall<TResponse>(
+            responseStream,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose
+        );
+    }
+
+    public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(context);
+        var requestStream =
+            typeof(TRequest) == typeof(TRequestMessage)
+                ? new ConditionalAvailabilityClientAsyncStreamWriter<TRequest>(call.RequestStream,
+                    message => !ReferenceEquals(message, null) && _availableForRequestStreamMessage((TRequestMessage)message))
+                : call.RequestStream;
+        var responseStream =
+            typeof(TResponse) == typeof(TResponseMessage)
+                ? new ConditionalAvailabilityAsyncStreamReader<TResponse>(call.ResponseStream,
+                    message => !ReferenceEquals(message, null) && _availableForResponseStreamMessage((TResponseMessage)message))
+                : call.ResponseStream;
+        return new AsyncDuplexStreamingCall<TRequest, TResponse>(
+            requestStream,
+            responseStream,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose);    
+    }
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ControlledAvailabilityAsyncStreamReader.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ControlledAvailabilityAsyncStreamReader.cs
@@ -1,0 +1,23 @@
+using Grpc.Core;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+internal class ControlledAvailabilityAsyncStreamReader<TResponse> : IAsyncStreamReader<TResponse>
+{
+    private readonly IAsyncStreamReader<TResponse> _reader;
+    private readonly Func<bool> _available;
+
+    public ControlledAvailabilityAsyncStreamReader(IAsyncStreamReader<TResponse> reader, Func<bool> available)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _available = available ?? throw new ArgumentNullException(nameof(available));
+    }
+    
+    public Task<bool> MoveNext(CancellationToken cancellationToken)
+    {
+        if (!_available()) throw new RpcException(new Status(StatusCode.Unavailable, ""));
+        return _reader.MoveNext(cancellationToken);
+    }
+
+    public TResponse Current => !_available() ? throw new RpcException(new Status(StatusCode.Unavailable, "")) : _reader.Current;
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ControlledAvailabilityClientAsyncStreamWriter.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ControlledAvailabilityClientAsyncStreamWriter.cs
@@ -1,0 +1,33 @@
+using Grpc.Core;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+internal class ControlledAvailabilityClientAsyncStreamWriter<TRequest> : IClientStreamWriter<TRequest>
+{
+    private readonly IClientStreamWriter<TRequest> _writer;
+    private readonly Func<bool> _available;
+
+    public ControlledAvailabilityClientAsyncStreamWriter(IClientStreamWriter<TRequest> writer, Func<bool> available)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _available = available ?? throw new ArgumentNullException(nameof(available));
+    }
+
+    public Task WriteAsync(TRequest message)
+    {
+        if (!_available()) throw new RpcException(new Status(StatusCode.Unavailable, ""));
+        return _writer.WriteAsync(message);
+    }
+
+    public WriteOptions? WriteOptions
+    {
+        get => _writer.WriteOptions;
+        set => _writer.WriteOptions = value;
+    }
+    
+    public Task CompleteAsync()
+    {
+        if (!_available()) throw new RpcException(new Status(StatusCode.Unavailable, ""));
+        return _writer.CompleteAsync();
+    }
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ControlledAvailabilityInterceptor.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/ControlledAvailabilityInterceptor.cs
@@ -1,0 +1,72 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+public class ControlledAvailabilityInterceptor : Interceptor
+{
+    public bool Available { get; set; } = true;
+
+    public override TResponse BlockingUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context,
+        BlockingUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        var response = continuation(request, context);
+        return Available ? response : throw new RpcException(new Status(StatusCode.Unavailable, ""));
+    }
+
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(request, context);
+        var responseAsync = Task.Run(async () =>
+            Available ? await call.ResponseAsync : throw new RpcException(new Status(StatusCode.Unavailable, ""))
+        );
+        return new AsyncUnaryCall<TResponse>(
+            responseAsync,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose);
+    }
+
+    public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(context);
+        var responseAsync = Task.Run(async () =>
+            Available ? await call.ResponseAsync : throw new RpcException(new Status(StatusCode.Unavailable, ""))
+        );
+        return new AsyncClientStreamingCall<TRequest, TResponse>(
+            new ControlledAvailabilityClientAsyncStreamWriter<TRequest>(call.RequestStream, () => Available),
+            responseAsync,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose);
+    }
+
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context, AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(request, context);
+        return new AsyncServerStreamingCall<TResponse>(
+            new ControlledAvailabilityAsyncStreamReader<TResponse>(call.ResponseStream, () => Available),
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose);
+    }
+
+    public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(context);
+        return new AsyncDuplexStreamingCall<TRequest, TResponse>(
+            new ControlledAvailabilityClientAsyncStreamWriter<TRequest>(call.RequestStream, () => Available),
+            new ControlledAvailabilityAsyncStreamReader<TResponse>(call.ResponseStream, () => Available),
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose);
+    }
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/SkipReadFromAsyncStreamReader.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/SkipReadFromAsyncStreamReader.cs
@@ -1,0 +1,27 @@
+using Grpc.Core;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+internal class SkipReadFromAsyncStreamReader<TResponse> : IAsyncStreamReader<TResponse>
+{
+    private readonly IAsyncStreamReader<TResponse> _reader;
+    private readonly Predicate<object?> _skip;
+
+    public SkipReadFromAsyncStreamReader(IAsyncStreamReader<TResponse> reader, Predicate<object?> skip)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _skip = skip ?? throw new ArgumentNullException(nameof(skip));
+    }
+        
+    public async Task<bool> MoveNext(CancellationToken cancellationToken)
+    {
+        var moved = await _reader.MoveNext(cancellationToken);
+        while (moved && _skip(_reader.Current))
+        {
+            moved = await _reader.MoveNext(cancellationToken);
+        }
+        return moved;
+    }
+
+    public TResponse Current => _reader.Current;
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/SkipStreamMessageInterceptor.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/SkipStreamMessageInterceptor.cs
@@ -1,0 +1,77 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+public class SkipStreamMessageInterceptor<TRequestMessage, TResponseMessage> : Interceptor
+{
+    private readonly Predicate<TRequestMessage> _skipRequestStreamMessage;
+    private readonly Predicate<TResponseMessage> _skipResponseStreamMessage;
+
+    public SkipStreamMessageInterceptor(Predicate<TRequestMessage> skipRequestStreamMessage, Predicate<TResponseMessage> skipResponseStreamMessage)
+    {
+        _skipRequestStreamMessage = skipRequestStreamMessage ?? throw new ArgumentNullException(nameof(skipRequestStreamMessage));
+        _skipResponseStreamMessage = skipResponseStreamMessage ?? throw new ArgumentNullException(nameof(skipResponseStreamMessage));
+    }
+
+    public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(context);
+        var requestStream =
+            typeof(TRequest) == typeof(TRequestMessage)
+                ? new SkipWriteToClientAsyncStreamWriter<TRequest>(call.RequestStream,
+                    message => !ReferenceEquals(message, null) && _skipRequestStreamMessage((TRequestMessage)message))
+                : call.RequestStream;
+        return new AsyncClientStreamingCall<TRequest, TResponse>(
+            requestStream,
+            call.ResponseAsync,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose
+        );
+    }
+
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context, AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(request, context);
+        var responseStream =
+                typeof(TResponse) == typeof(TResponseMessage)
+                    ? new SkipReadFromAsyncStreamReader<TResponse>(call.ResponseStream,
+                        message => !ReferenceEquals(message, null) && _skipResponseStreamMessage((TResponseMessage)message))
+                    : call.ResponseStream;
+        return new AsyncServerStreamingCall<TResponse>(
+            responseStream,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose
+        );
+    }
+
+    public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(context);
+        var requestStream =
+            typeof(TRequest) == typeof(TRequestMessage)
+                ? new SkipWriteToClientAsyncStreamWriter<TRequest>(call.RequestStream,
+                    message => !ReferenceEquals(message, null) && _skipRequestStreamMessage((TRequestMessage)message))
+                : call.RequestStream;
+        var responseStream =
+            typeof(TResponse) == typeof(TResponseMessage)
+                ? new SkipReadFromAsyncStreamReader<TResponse>(call.ResponseStream,
+                    message => !ReferenceEquals(message, null) && _skipResponseStreamMessage((TResponseMessage)message))
+                : call.ResponseStream;
+        return new AsyncDuplexStreamingCall<TRequest, TResponse>(
+            requestStream,
+            responseStream,
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose);    
+    }
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/SkipWriteToClientAsyncStreamWriter.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/Interceptors/SkipWriteToClientAsyncStreamWriter.cs
@@ -1,0 +1,30 @@
+using Grpc.Core;
+
+namespace AxonIQ.AxonServer.Connector.Tests.Interceptors;
+
+internal class SkipWriteToClientAsyncStreamWriter<TRequest> : IClientStreamWriter<TRequest>
+{
+    private readonly IClientStreamWriter<TRequest> _writer;
+    private readonly Predicate<object?> _skip;
+
+    public SkipWriteToClientAsyncStreamWriter(IClientStreamWriter<TRequest> writer, Predicate<object?> skip)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _skip = skip ?? throw new ArgumentNullException(nameof(skip));
+    }
+    public Task WriteAsync(TRequest message)
+    {
+        return _skip(message) ? Task.CompletedTask : _writer.WriteAsync(message);
+    }
+
+    public WriteOptions? WriteOptions
+    {
+        get => _writer.WriteOptions;
+        set => _writer.WriteOptions = value;
+    }
+    
+    public Task CompleteAsync()
+    {
+        return _writer.CompleteAsync();
+    }
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/PermitCountTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/PermitCountTests.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
+using Io.Axoniq.Axonserver.Grpc.Control;
 using Xunit;
+using YamlDotNet.Core.Tokens;
 
 namespace AxonIQ.AxonServer.Connector.Tests;
 


### PR DESCRIPTION
This PR adds support for adding gRPC interceptors using the options builder (primarily to simulate error conditions, but it has other applications). Additionally, it applies `.ConfigureAwait(false)` all over the place. A couple of interceptors were added to allow controlling availability (based on setting or per message) and to skip writing / reading specific messages (aka drop messages), for use in tests. This allowed bringing "recovery after heartbeat" under test. Also discovered (and fixed) a nasty problem with `Grpc.Core` (https://github.com/grpc/grpc-dotnet/issues/1747).