### PR TITLE
Stand-alone axon server connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Renamed `AxonServerConnectionFactoryDefaults` to `AxonServerConnectorDefaults` to allow it to be shared between `AxonServerConnection` and `AxonServerConnectionFactory`
+- Renamed `AxonServerConnectionFactoryConfiguration` to `AxonServerConnectorConfiguration`  to allow it to be shared between `AxonServerConnection` and `AxonServerConnectionFactory`
+- Renamed `AxonServerConnectionHeaders` to `AxonServerConnectorHeaders` to allow it to be shared between `AxonServerConnection` and `AxonServerConnectionFactory`
+- Renamed `IAxonServerConnectionFactoryOptionsBuilder` to `IAxonServerConnectorOptionsBuilder` to allow it to be shared between `AxonServerConnection` and `AxonServerConnectionFactory`
+- Renamed `AxonServerConnectionFactoryOptions` to `AxonServerConnectorOptions` to allow it to be shared between `AxonServerConnection` and `AxonServerConnectionFactory`
+- Introduction of `IOwnerAxonServerConnection` to allow sharing behavior between a `SharedAxonServerConnection` and an `AxonServerConnection` 
+- Renamed internal `AxonServerConnection` to `SharedAxonServerConnection` to make room for a public `AxonServerConnection`
+- Introduction of `AxonServerConnection` as a stand alone connection that takes a `Context` and configuration options. This eases registration in the inversion of control container and auto connects whenever a property of the connection is accessed, except for `ClientIdentity`, `Context`, `IsConnected`, `IsClosed`, `IsReady`. Ideal for those scenarios where the consuming code is only ever interacting with one `Context`. Extended `ServiceCollectionExtensions` with `AddAxonServerConnection` overloads similar to `AddAxonServerConnectionFactory` overloads.
 - Public API generation and verification
 - Initial version
 

--- a/src/AxonIQ.AxonServer.Connector/AdminChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/AdminChannel.cs
@@ -8,7 +8,7 @@ namespace AxonIQ.AxonServer.Connector;
 
 internal class AdminChannel : IAdminChannel
 {
-    public AdminChannel(AxonServerConnection connection)
+    public AdminChannel(IOwnerAxonServerConnection connection)
     {
         if (connection == null) throw new ArgumentNullException(nameof(connection));
 

--- a/src/AxonIQ.AxonServer.Connector/AxonActor.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonActor.cs
@@ -99,6 +99,12 @@ internal class AxonActor<TMessage, TState> : IAxonActor<TMessage>, IAsyncDisposa
         ThrowIfDisposed();
         return _scheduler.ScheduleTaskAsync(() => TellAsync(message, ct), due);
     }
+    
+    public bool TryTell(TMessage message)
+    {
+        ThrowIfDisposed();
+        return _inbox.Writer.TryWrite(message);
+    }
 
     public ValueTask TellAsync(TMessage message)
     {

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnectionDefaults.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnectionDefaults.cs
@@ -2,7 +2,7 @@ using System.Net;
 
 namespace AxonIQ.AxonServer.Connector;
 
-public static class AxonServerConnectionFactoryDefaults
+public static class AxonServerConnectionDefaults
 {
     public static readonly int Port = 8124;
     

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnectorConfiguration.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnectorConfiguration.cs
@@ -1,6 +1,6 @@
 namespace AxonIQ.AxonServer.Connector;
 
-public static class AxonServerConnectionFactoryConfiguration
+public static class AxonServerConnectorConfiguration
 {
     public const string DefaultSection = "AxonIQ";
     public const string ComponentName = nameof(ComponentName);

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnectorDefaults.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnectorDefaults.cs
@@ -2,7 +2,7 @@ using System.Net;
 
 namespace AxonIQ.AxonServer.Connector;
 
-public static class AxonServerConnectionDefaults
+public static class AxonServerConnectorDefaults
 {
     public static readonly int Port = 8124;
     

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnectorHeaders.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnectorHeaders.cs
@@ -1,6 +1,6 @@
 namespace AxonIQ.AxonServer.Connector;
 
-public static class AxonServerConnectionHeaders
+public static class AxonServerConnectorHeaders
 {
     public const string AccessToken = "AxonIQ-Access-Token";
     public const string Context = "AxonIQ-Context";

--- a/src/AxonIQ.AxonServer.Connector/AxonServerConnectorOptions.cs
+++ b/src/AxonIQ.AxonServer.Connector/AxonServerConnectorOptions.cs
@@ -140,9 +140,9 @@ public class AxonServerConnectorOptions
         {
             _componentName = componentName;
             _clientInstanceId = clientInstanceId;
-            _routingServers = new List<DnsEndPoint>(AxonServerConnectionDefaults.RoutingServers);
+            _routingServers = new List<DnsEndPoint>(AxonServerConnectorDefaults.RoutingServers);
             _clientTags = new Dictionary<string, string>();
-            foreach (var (key, value) in AxonServerConnectionDefaults.ClientTags)
+            foreach (var (key, value) in AxonServerConnectorDefaults.ClientTags)
             {
                 _clientTags.Add(key, value);
             }
@@ -152,10 +152,10 @@ public class AxonServerConnectorOptions
             _clock = null;
             _grpcChannelOptions = null;
             _interceptors = new List<Interceptor>();
-            _commandPermits = AxonServerConnectionDefaults.DefaultCommandPermits;
-            _queryPermits = AxonServerConnectionDefaults.DefaultQueryPermits;
-            _eventProcessorUpdateFrequency = AxonServerConnectionDefaults.DefaultEventProcessorUpdateFrequency;
-            _reconnectOptions = AxonServerConnectionDefaults.DefaultReconnectOptions;
+            _commandPermits = AxonServerConnectorDefaults.DefaultCommandPermits;
+            _queryPermits = AxonServerConnectorDefaults.DefaultQueryPermits;
+            _eventProcessorUpdateFrequency = AxonServerConnectorDefaults.DefaultEventProcessorUpdateFrequency;
+            _reconnectOptions = AxonServerConnectorDefaults.DefaultReconnectOptions;
         }
 
         public IAxonServerConnectorOptionsBuilder AsComponentName(ComponentName name)
@@ -289,14 +289,14 @@ public class AxonServerConnectorOptions
 
         public IAxonServerConnectorOptionsBuilder WithCommandPermits(PermitCount count)
         {
-            _commandPermits = PermitCount.Max(AxonServerConnectionDefaults.MinimumCommandPermits, count);
+            _commandPermits = PermitCount.Max(AxonServerConnectorDefaults.MinimumCommandPermits, count);
 
             return this;
         }
 
         public IAxonServerConnectorOptionsBuilder WithQueryPermits(PermitCount count)
         {
-            _queryPermits = PermitCount.Max(AxonServerConnectionDefaults.MinimumQueryPermits, count);
+            _queryPermits = PermitCount.Max(AxonServerConnectorDefaults.MinimumQueryPermits, count);
 
             return this;
         }
@@ -310,7 +310,7 @@ public class AxonServerConnectorOptions
 
         public IAxonServerConnectorOptionsBuilder WithEventProcessorUpdateFrequency(TimeSpan frequency)
         {
-            _eventProcessorUpdateFrequency = TimeSpanMath.Max(AxonServerConnectionDefaults.DefaultEventProcessorUpdateFrequency, frequency);
+            _eventProcessorUpdateFrequency = TimeSpanMath.Max(AxonServerConnectorDefaults.DefaultEventProcessorUpdateFrequency, frequency);
 
             return this;
         }
@@ -319,7 +319,7 @@ public class AxonServerConnectorOptions
         {
             if (_routingServers.Count == 0)
             {
-                _routingServers.AddRange(AxonServerConnectionDefaults.RoutingServers);
+                _routingServers.AddRange(AxonServerConnectorDefaults.RoutingServers);
             }
 
             return new AxonServerConnectorOptions(

--- a/src/AxonIQ.AxonServer.Connector/CommandChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/CommandChannel.cs
@@ -9,13 +9,13 @@ internal class CommandChannel : ICommandChannel, IAsyncDisposable
 {
     public static readonly TimeSpan PurgeInterval = TimeSpan.FromSeconds(15);
     
-    private readonly AxonServerConnection _connection;
+    private readonly IOwnerAxonServerConnection _connection;
     private readonly AxonActor<Message, State> _actor;
     private readonly TimeSpan _purgeInterval;
     private readonly ILogger<CommandChannel> _logger;
 
     public CommandChannel(
-        AxonServerConnection connection,
+        IOwnerAxonServerConnection connection,
         IScheduler scheduler,
         PermitCount permits,
         PermitCount permitsBatch,
@@ -26,7 +26,7 @@ internal class CommandChannel : ICommandChannel, IAsyncDisposable
     }
 
     public CommandChannel(
-        AxonServerConnection connection,
+        IOwnerAxonServerConnection connection,
         IScheduler scheduler,
         PermitCount permits,
         PermitCount permitsBatch,

--- a/src/AxonIQ.AxonServer.Connector/Connected.cs
+++ b/src/AxonIQ.AxonServer.Connector/Connected.cs
@@ -1,0 +1,7 @@
+namespace AxonIQ.AxonServer.Connector;
+
+internal static class Connected
+{
+    public const long No = 0L;
+    public const long Yes = 1L;
+}

--- a/src/AxonIQ.AxonServer.Connector/Context.cs
+++ b/src/AxonIQ.AxonServer.Connector/Context.cs
@@ -32,6 +32,6 @@ public readonly struct Context : IEquatable<Context>
     public void WriteTo(Metadata metadata)
     {
         if (metadata == null) throw new ArgumentNullException(nameof(metadata));
-        metadata.Add(AxonServerConnectionHeaders.Context, _value);
+        metadata.Add(AxonServerConnectorHeaders.Context, _value);
     }
 }

--- a/src/AxonIQ.AxonServer.Connector/ControlChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/ControlChannel.cs
@@ -7,13 +7,13 @@ namespace AxonIQ.AxonServer.Connector;
 
 internal class ControlChannel : IControlChannel, IAsyncDisposable
 {
-    private readonly AxonServerConnection _connection;
+    private readonly IOwnerAxonServerConnection _connection;
     private readonly TimeSpan _eventProcessorUpdateFrequency;
     private readonly ILogger<ControlChannel> _logger;
     private readonly AxonActor<Message, State> _actor;
 
     public ControlChannel(
-        AxonServerConnection connection,
+        IOwnerAxonServerConnection connection,
         IScheduler scheduler,
         TimeSpan eventProcessorUpdateFrequency,
         ILoggerFactory loggerFactory)

--- a/src/AxonIQ.AxonServer.Connector/EventChannel.cs
+++ b/src/AxonIQ.AxonServer.Connector/EventChannel.cs
@@ -7,7 +7,7 @@ namespace AxonIQ.AxonServer.Connector;
 
 internal class EventChannel : IEventChannel, IDisposable
 {
-    private readonly AxonServerConnection _connection;
+    private readonly IOwnerAxonServerConnection _connection;
     private readonly Func<DateTimeOffset> _clock;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<EventChannel> _logger;
@@ -16,7 +16,7 @@ internal class EventChannel : IEventChannel, IDisposable
     private long _disposed;
 
     public EventChannel(
-        AxonServerConnection connection,
+        IOwnerAxonServerConnection connection,
         Func<DateTimeOffset> clock,
         ILoggerFactory loggerFactory)
     {

--- a/src/AxonIQ.AxonServer.Connector/IAxonServerConnectorOptionsBuilder.cs
+++ b/src/AxonIQ.AxonServer.Connector/IAxonServerConnectorOptionsBuilder.cs
@@ -1,127 +1,126 @@
 using System.Net;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace AxonIQ.AxonServer.Connector;
 
-public interface IAxonServerConnectionFactoryOptionsBuilder
+public interface IAxonServerConnectorOptionsBuilder
 {
     /// <summary>
     /// Specifies the component name this factory identifies as to the server.
     /// </summary>
     /// <param name="name">The component name</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder AsComponentName(ComponentName name);
+    IAxonServerConnectorOptionsBuilder AsComponentName(ComponentName name);
     /// <summary>
     /// Specifies the client instance identifier this factory identifies as to the server.
     /// </summary>
     /// <param name="id">The client instance identifier</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder AsClientInstanceId(ClientInstanceId id);
+    IAxonServerConnectorOptionsBuilder AsClientInstanceId(ClientInstanceId id);
     /// <summary>
     /// Indicates the factory should use the default server addresses to connect to the server.
     /// </summary>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithDefaultRoutingServers();
+    IAxonServerConnectorOptionsBuilder WithDefaultRoutingServers();
     /// <summary>
     /// Specifies the server addresses the factory should use to connect to the server.
     /// </summary>
     /// <param name="servers">One or more server addresses to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithRoutingServers(params DnsEndPoint[] servers);
+    IAxonServerConnectorOptionsBuilder WithRoutingServers(params DnsEndPoint[] servers);
     /// <summary>
     /// Specifies the server addresses the factory should use to connect to the server.
     /// </summary>
     /// <param name="servers">One or more server addresses to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithRoutingServers(IEnumerable<DnsEndPoint> servers);
+    IAxonServerConnectorOptionsBuilder WithRoutingServers(IEnumerable<DnsEndPoint> servers);
     /// <summary>
     /// Indicates the factory should not authenticate to the server (e.g. if the server has disabled authentication).
     /// </summary>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithoutAuthentication();
+    IAxonServerConnectorOptionsBuilder WithoutAuthentication();
     /// <summary>
     /// Indicates the factory should authenticate to the server using the specified <c>token</c>.
     /// </summary>
     /// <param name="token">The token used to authenticate</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithAuthenticationToken(string token);
+    IAxonServerConnectorOptionsBuilder WithAuthenticationToken(string token);
     /// <summary>
     /// Specifies a client tag the factory should use.
     /// </summary>
     /// <param name="key">The key of the tag</param>
     /// <param name="value">The value of the tag</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithClientTag(string key, string value);
+    IAxonServerConnectorOptionsBuilder WithClientTag(string key, string value);
     /// <summary>
     /// Specifies one or more clients tag the factory should use.
     /// </summary>
     /// <param name="tags">The tags to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithClientTags(params KeyValuePair<string, string>[] tags);
+    IAxonServerConnectorOptionsBuilder WithClientTags(params KeyValuePair<string, string>[] tags);
     /// <summary>
     /// Specifies one or more clients tag the factory should use.
     /// </summary>
     /// <param name="tags">The tags to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithClientTags(IEnumerable<KeyValuePair<string, string>> tags);
+    IAxonServerConnectorOptionsBuilder WithClientTags(IEnumerable<KeyValuePair<string, string>> tags);
     /// <summary>
     /// Specifies the logger factory the factory should use.
     /// </summary>
     /// <param name="loggerFactory">The logger factory to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
     /// <remarks>This method must not be called if using any of the <see cref="AddAxonServerConnectionFactory()"/> methods on the <see cref="ServiceCollection"/>.</remarks>
-    IAxonServerConnectionFactoryOptionsBuilder WithLoggerFactory(ILoggerFactory loggerFactory);
+    IAxonServerConnectorOptionsBuilder WithLoggerFactory(ILoggerFactory loggerFactory);
     /// <summary>
     /// Specifies the clock the factory should use.
     /// </summary>
     /// <param name="clock">The clock to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
     /// <remarks>This method exists for testing purposes only.</remarks>
-    IAxonServerConnectionFactoryOptionsBuilder WithClock(Func<DateTimeOffset> clock);
+    IAxonServerConnectorOptionsBuilder WithClock(Func<DateTimeOffset> clock);
     /// <summary>
     /// Specifies the gRPC channel options the factory should use.
     /// </summary>
     /// <param name="grpcChannelOptions">The gRPC channel options to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
     /// <remarks>The factory will override certain options if it relies on their functionality.</remarks>
-    IAxonServerConnectionFactoryOptionsBuilder WithGrpcChannelOptions(GrpcChannelOptions grpcChannelOptions);
+    IAxonServerConnectorOptionsBuilder WithGrpcChannelOptions(GrpcChannelOptions grpcChannelOptions);
     /// <summary>
     /// Specifies the gRPC interceptors the factory should use.
     /// </summary>
     /// <param name="interceptors">The gRPC interceptors to use</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
     /// <remarks>This method exists for testing purposes only.</remarks>
-    IAxonServerConnectionFactoryOptionsBuilder WithInterceptors(params Interceptor[] interceptors);
+    IAxonServerConnectorOptionsBuilder WithInterceptors(params Interceptor[] interceptors);
     /// <summary>
     /// Specifies the number of commands each connection of the factory can process.
     /// </summary>
     /// <param name="count">The number of commands to process</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithCommandPermits(PermitCount count);
+    IAxonServerConnectorOptionsBuilder WithCommandPermits(PermitCount count);
     /// <summary>
     /// Specifies the number of queries each connection of the factory can process.
     /// </summary>
     /// <param name="count">The number of queries to process</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithQueryPermits(PermitCount count);
+    IAxonServerConnectorOptionsBuilder WithQueryPermits(PermitCount count);
     /// <summary>
     /// Specifies the reconnect options each connection of the factory should use.
     /// </summary>
     /// <param name="options">The reconnect options</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithReconnectOptions(ReconnectOptions options);
+    IAxonServerConnectorOptionsBuilder WithReconnectOptions(ReconnectOptions options);
     /// <summary>
     /// Specifies the frequency with which event processors are polled to provide information and transmit it to the server.  
     /// </summary>
     /// <param name="frequency">The frequency with which to poll</param>
     /// <returns>An instance of the builder to continue configuring options with.</returns>
-    IAxonServerConnectionFactoryOptionsBuilder WithEventProcessorUpdateFrequency(TimeSpan frequency);
+    IAxonServerConnectorOptionsBuilder WithEventProcessorUpdateFrequency(TimeSpan frequency);
     /// <summary>
     /// Builds the configured options and falls back to defaults for those options that have not been specified.
     /// </summary>
     /// <returns>An instance of the configured options.</returns>
-    AxonServerConnectionFactoryOptions Build();
+    AxonServerConnectorOptions Build();
 }

--- a/src/AxonIQ.AxonServer.Connector/IOwnerAxonServerConnection.cs
+++ b/src/AxonIQ.AxonServer.Connector/IOwnerAxonServerConnection.cs
@@ -1,0 +1,16 @@
+using Grpc.Core;
+
+namespace AxonIQ.AxonServer.Connector;
+
+internal interface IOwnerAxonServerConnection
+{
+    ClientIdentity ClientIdentity { get; }
+
+    Context Context { get;  }
+    
+    CallInvoker CallInvoker { get; }
+
+    ValueTask ReconnectAsync();
+
+    ValueTask CheckReadinessAsync();
+}

--- a/src/AxonIQ.AxonServer.Connector/ServiceCollectionExtensions.cs
+++ b/src/AxonIQ.AxonServer.Connector/ServiceCollectionExtensions.cs
@@ -7,38 +7,141 @@ namespace AxonIQ.AxonServer.Connector;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds an Axon Server connection to the specified <paramref name="context"/>. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection to.</param>
+    /// <param name="context">The context to connect to.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddAxonServerConnection(this IServiceCollection services, Context context)
+    {
+        var builder = AxonServerConnectorOptions.For(ComponentName.GenerateRandomName());
+        AddAxonServerConnectionCore(services, context, builder);
+        return services;
+    }
+
+    /// <summary>
+    /// Adds an Axon Server connection to the specified <paramref name="context"/> using the specified <paramref name="configuration"/> settings. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection to.</param>
+    /// <param name="context">The context to connect to.</param>
+    /// <param name="configuration">The configuration to read settings from.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddAxonServerConnection(this IServiceCollection services,
+        Context context,
+        IConfiguration configuration)
+    {
+        if (configuration == null)
+            throw new ArgumentNullException(nameof(configuration));
+        var builder = AxonServerConnectorOptions.FromConfiguration(configuration);
+        AddAxonServerConnectionCore(services, context, builder);
+        return services;
+    }
+
+    /// <summary>
+    /// Adds an Axon Server connection to the specified <paramref name="context"/> using the specified <paramref name="options"/>. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection to.</param>
+    /// <param name="context">The context to connect to.</param>
+    /// <param name="options">The options to use.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddAxonServerConnection(this IServiceCollection services,
+        Context context,
+        AxonServerConnectorOptions options)
+    {
+        if (options == null) throw new ArgumentNullException(nameof(options));
+        services.AddSingleton(_ => new AxonServerConnection(context, options));
+        return services;
+    }
+
+    /// <summary>
+    /// Adds an Axon Server connection to the specified <paramref name="context"/> using the specified <paramref name="configure"/> builder. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection to.</param>
+    /// <param name="context">The context to connect to.</param>
+    /// <param name="configure">The callback to configure options.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddAxonServerConnection(this IServiceCollection services,
+        Context context,
+        Action<IAxonServerConnectorOptionsBuilder> configure)
+    {
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        var builder = AxonServerConnectorOptions.For(ComponentName.GenerateRandomName());
+        configure(builder);
+        AddAxonServerConnectionCore(services, context, builder);
+        return services;
+    }
+
+    private static void AddAxonServerConnectionCore(
+        IServiceCollection services,
+        Context context,
+        IAxonServerConnectorOptionsBuilder builder)
+    {
+        services.AddSingleton(sp =>
+            new AxonServerConnection(
+                context,
+                builder
+                    .WithLoggerFactory(sp.GetService<ILoggerFactory>() ?? new NullLoggerFactory())
+                    .Build()));
+    }
+    
+    /// <summary>
+    /// Adds an Axon Server connection factory. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection factory to.</param>
+    /// <returns>The service collection.</returns>
     public static IServiceCollection AddAxonServerConnectionFactory(this IServiceCollection services)
     {
-        var builder = AxonServerConnectionFactoryOptions.For(ComponentName.GenerateRandomName());
+        var builder = AxonServerConnectorOptions.For(ComponentName.GenerateRandomName());
         AddAxonServerConnectionFactoryCore(services, builder);
         return services;
     }
 
+    /// <summary>
+    /// Adds an Axon Server connection factory using the specified <paramref name="configuration"/> settings. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection factory to.</param>
+    /// <param name="configuration">The configuration to read settings from.</param>
+    /// <returns>The service collection.</returns>
     public static IServiceCollection AddAxonServerConnectionFactory(this IServiceCollection services,
         IConfiguration configuration)
     {
         if (configuration == null)
             throw new ArgumentNullException(nameof(configuration));
-        var builder = AxonServerConnectionFactoryOptions.FromConfiguration(configuration);
+        var builder = AxonServerConnectorOptions.FromConfiguration(configuration);
         AddAxonServerConnectionFactoryCore(services, builder);
         return services;
     }
 
+    /// <summary>
+    /// Adds an Axon Server connection factory using the specified <paramref name="options"/>. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection factory to.</param>
+    /// <param name="options">The options to use.</param>
+    /// <returns>The service collection.</returns>
     public static IServiceCollection AddAxonServerConnectionFactory(this IServiceCollection services,
-        AxonServerConnectionFactoryOptions options)
+        AxonServerConnectorOptions options)
     {
         if (options == null) throw new ArgumentNullException(nameof(options));
-        services.AddSingleton(sp => new AxonServerConnectionFactory(options));
+        services.AddSingleton(_ => new AxonServerConnectionFactory(options));
         return services;
     }
 
+    /// <summary>
+    /// Adds an Axon Server connection factory using the specified <paramref name="configure"/> builder. 
+    /// </summary>
+    /// <param name="services">The service collection to add the connection factory to.</param>
+    /// <param name="configure">The callback to configure options.</param>
+    /// <returns>The service collection.</returns>
     public static IServiceCollection AddAxonServerConnectionFactory(this IServiceCollection services,
-        Action<IAxonServerConnectionFactoryOptionsBuilder> configure)
+        Action<IAxonServerConnectorOptionsBuilder> configure)
     {
         if (configure == null)
             throw new ArgumentNullException(nameof(configure));
 
-        var builder = AxonServerConnectionFactoryOptions.For(ComponentName.GenerateRandomName());
+        var builder = AxonServerConnectorOptions.For(ComponentName.GenerateRandomName());
         configure(builder);
         AddAxonServerConnectionFactoryCore(services, builder);
         return services;
@@ -46,7 +149,7 @@ public static class ServiceCollectionExtensions
 
     private static void AddAxonServerConnectionFactoryCore(
         IServiceCollection services,
-        IAxonServerConnectionFactoryOptionsBuilder builder)
+        IAxonServerConnectorOptionsBuilder builder)
     {
         services.AddSingleton(sp =>
             new AxonServerConnectionFactory(

--- a/src/AxonIQ.AxonServer.Connector/TokenBasedServerAuthentication.cs
+++ b/src/AxonIQ.AxonServer.Connector/TokenBasedServerAuthentication.cs
@@ -14,6 +14,6 @@ internal class TokenBasedServerAuthentication : IAxonServerAuthentication
     public void WriteTo(Metadata metadata)
     {
         if (metadata == null) throw new ArgumentNullException(nameof(metadata));
-        metadata.Add(AxonServerConnectionHeaders.AccessToken, Token);
+        metadata.Add(AxonServerConnectorHeaders.AccessToken, Token);
     }
 }

--- a/src/Benchmarks/ParallelPingPongCommandBenchmark.cs
+++ b/src/Benchmarks/ParallelPingPongCommandBenchmark.cs
@@ -75,12 +75,12 @@ public class ParallelPingPongCommandBenchmark : IBenchmark
         var clientInstance1 = new ClientInstanceId("1");
         var clientInstance2 = new ClientInstanceId("2");
 
-        _pingFactory = new AxonServerConnectionFactory(AxonServerConnectionFactoryOptions
+        _pingFactory = new AxonServerConnectionFactory(AxonServerConnectorOptions
             .For(component, clientInstance1)
             .WithRoutingServers(_server.GetGrpcEndpoint())
             .WithLoggerFactory(new NullLoggerFactory())
             .Build());
-        _pongFactory = new AxonServerConnectionFactory(AxonServerConnectionFactoryOptions
+        _pongFactory = new AxonServerConnectionFactory(AxonServerConnectorOptions
             .For(component, clientInstance2)
             .WithRoutingServers(_server.GetGrpcEndpoint())
             .WithLoggerFactory(new NullLoggerFactory())

--- a/src/Benchmarks/PingDotNetPongJavaCommandInteropBenchmark.cs
+++ b/src/Benchmarks/PingDotNetPongJavaCommandInteropBenchmark.cs
@@ -85,7 +85,7 @@ public class PingDotNetPongJavaCommandInteropBenchmark : IBenchmark
         var component = new ComponentName(nameof(PingPongCommandBenchmark));
         var clientInstance1 = new ClientInstanceId("dotnet-client");
 
-        _pingFactory = new AxonServerConnectionFactory(AxonServerConnectionFactoryOptions
+        _pingFactory = new AxonServerConnectionFactory(AxonServerConnectorOptions
             .For(component, clientInstance1)
             .WithRoutingServers(_server.GetGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory)

--- a/src/Benchmarks/PingPongCommandBenchmark.cs
+++ b/src/Benchmarks/PingPongCommandBenchmark.cs
@@ -61,12 +61,12 @@ public class PingPongCommandBenchmark : IBenchmark
         var clientInstance1 = new ClientInstanceId("1");
         var clientInstance2 = new ClientInstanceId("2");
 
-        _pingFactory = new AxonServerConnectionFactory(AxonServerConnectionFactoryOptions
+        _pingFactory = new AxonServerConnectionFactory(AxonServerConnectorOptions
             .For(component, clientInstance1)
             .WithRoutingServers(_server.GetGrpcEndpoint())
             .WithLoggerFactory(new NullLoggerFactory())
             .Build());
-        _pongFactory = new AxonServerConnectionFactory(AxonServerConnectionFactoryOptions
+        _pongFactory = new AxonServerConnectionFactory(AxonServerConnectorOptions
             .For(component, clientInstance2)
             .WithRoutingServers(_server.GetGrpcEndpoint())
             .WithLoggerFactory(new NullLoggerFactory())

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -35,12 +35,12 @@ try
         var clientInstance1 = new ClientInstanceId("1");
         var clientInstance2 = new ClientInstanceId("2");
 
-        var instance1 = new AxonServerConnectionFactory(AxonServerConnectionFactoryOptions
+        var instance1 = new AxonServerConnectionFactory(AxonServerConnectorOptions
             .For(component, clientInstance1)
             .WithRoutingServers(server.GetGrpcEndpoint())
             .WithLoggerFactory(host.Services.GetRequiredService<ILoggerFactory>())
             .Build());
-        var instance2 = new AxonServerConnectionFactory(AxonServerConnectionFactoryOptions
+        var instance2 = new AxonServerConnectionFactory(AxonServerConnectorOptions
             .For(component, clientInstance2)
             .WithRoutingServers(server.GetGrpcEndpoint())
             .WithLoggerFactory(host.Services.GetRequiredService<ILoggerFactory>())

--- a/test/AxonIQ.AxonClusterIntegrationTests/AxonClusterAdminChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonClusterIntegrationTests/AxonClusterAdminChannelIntegrationTests.cs
@@ -32,12 +32,12 @@ public class AxonClusterAdminChannelIntegrationTests
     }
 
     private async Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_cluster.GetRandomGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);

--- a/test/AxonIQ.AxonClusterIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
+++ b/test/AxonIQ.AxonClusterIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
@@ -40,7 +40,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
         
         private AxonServerGrpcChannelFactory CreateSystemUnderTest(IReadOnlyList<DnsEndPoint> routingServers, IAxonServerAuthentication authentication)
@@ -109,7 +109,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory, Array.Empty<Interceptor>(),
                 new GrpcChannelOptions(),
-                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
 
         [Fact]
@@ -335,7 +335,7 @@ public class AxonServerGrpcChannelFactoryTests
                 var sut = new AxonServerGrpcChannelFactory(clientIdentity,
                     AxonServerAuthentication.UsingToken(template.Applications![0].Token!),
                     routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                    clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                    clock, AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout);
 
                 var result = await sut.Create(context);
 

--- a/test/AxonIQ.AxonClusterIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
+++ b/test/AxonIQ.AxonClusterIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
@@ -40,7 +40,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
         
         private AxonServerGrpcChannelFactory CreateSystemUnderTest(IReadOnlyList<DnsEndPoint> routingServers, IAxonServerAuthentication authentication)
@@ -109,7 +109,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory, Array.Empty<Interceptor>(),
                 new GrpcChannelOptions(),
-                clock, AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
 
         [Fact]
@@ -335,7 +335,7 @@ public class AxonServerGrpcChannelFactoryTests
                 var sut = new AxonServerGrpcChannelFactory(clientIdentity,
                     AxonServerAuthentication.UsingToken(template.Applications![0].Token!),
                     routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                    clock, AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                    clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
 
                 var result = await sut.Create(context);
 

--- a/test/AxonIQ.AxonServer.Connector.Tests/AsyncLockTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AsyncLockTests.cs
@@ -40,7 +40,7 @@ public class AsyncLockTests
     [Fact]
     public async Task RaceBetweenAcquireAsyncAndDisposeAsyncHasExpectedResult()
     {
-        var source = new CancellationTokenSource();
+        using var source = new CancellationTokenSource();
         var sut = new AsyncLock();
 
         if (Random.Shared.Next() % 2 == 0)

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerAuthenticationTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerAuthenticationTests.cs
@@ -73,7 +73,7 @@ public class AxonServerAuthenticationTests
 
         Assert.Equal(new Metadata
         {
-            { AxonServerConnectionHeaders.AccessToken, token }
+            { AxonServerConnectorHeaders.AccessToken, token }
         }, metadata, new MetadataEntryKeyValueComparer());
     }
 }

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryDefaultsTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryDefaultsTests.cs
@@ -8,7 +8,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void PortReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.Port;
+        var result = AxonServerConnectionDefaults.Port;
 
         Assert.Equal(8124, result);
     }
@@ -16,7 +16,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void RoutingServersReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.RoutingServers;
+        var result = AxonServerConnectionDefaults.RoutingServers;
 
         Assert.Equal(new List<DnsEndPoint>
         {
@@ -27,7 +27,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void ClientTagsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.ClientTags;
+        var result = AxonServerConnectionDefaults.ClientTags;
 
         Assert.Empty(result);
     }
@@ -35,7 +35,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void AuthenticationReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.Authentication;
+        var result = AxonServerConnectionDefaults.Authentication;
 
         Assert.Same(AxonServerAuthentication.None, result);
     }
@@ -43,7 +43,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void MinimumCommandPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.MinimumCommandPermits;
+        var result = AxonServerConnectionDefaults.MinimumCommandPermits;
 
         Assert.Equal(new PermitCount(16), result);
     }
@@ -51,7 +51,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void DefaultCommandPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.DefaultCommandPermits;
+        var result = AxonServerConnectionDefaults.DefaultCommandPermits;
 
         Assert.Equal(new PermitCount(5_000), result);
     }
@@ -59,7 +59,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void MinimumQueryPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.MinimumQueryPermits;
+        var result = AxonServerConnectionDefaults.MinimumQueryPermits;
 
         Assert.Equal(new PermitCount(16), result);
     }
@@ -67,7 +67,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void DefaultQueryPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryDefaults.DefaultQueryPermits;
+        var result = AxonServerConnectionDefaults.DefaultQueryPermits;
 
         Assert.Equal(new PermitCount(5_000), result);
     }
@@ -75,7 +75,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void DefaultReconnectOptions()
     {
-        var result = AxonServerConnectionFactoryDefaults.DefaultReconnectOptions;
+        var result = AxonServerConnectionDefaults.DefaultReconnectOptions;
         
         Assert.Equal(new ReconnectOptions(
             TimeSpan.FromMilliseconds(10000),

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryDefaultsTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryDefaultsTests.cs
@@ -8,7 +8,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void PortReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.Port;
+        var result = AxonServerConnectorDefaults.Port;
 
         Assert.Equal(8124, result);
     }
@@ -16,7 +16,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void RoutingServersReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.RoutingServers;
+        var result = AxonServerConnectorDefaults.RoutingServers;
 
         Assert.Equal(new List<DnsEndPoint>
         {
@@ -27,7 +27,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void ClientTagsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.ClientTags;
+        var result = AxonServerConnectorDefaults.ClientTags;
 
         Assert.Empty(result);
     }
@@ -35,7 +35,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void AuthenticationReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.Authentication;
+        var result = AxonServerConnectorDefaults.Authentication;
 
         Assert.Same(AxonServerAuthentication.None, result);
     }
@@ -43,7 +43,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void MinimumCommandPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.MinimumCommandPermits;
+        var result = AxonServerConnectorDefaults.MinimumCommandPermits;
 
         Assert.Equal(new PermitCount(16), result);
     }
@@ -51,7 +51,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void DefaultCommandPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.DefaultCommandPermits;
+        var result = AxonServerConnectorDefaults.DefaultCommandPermits;
 
         Assert.Equal(new PermitCount(5_000), result);
     }
@@ -59,7 +59,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void MinimumQueryPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.MinimumQueryPermits;
+        var result = AxonServerConnectorDefaults.MinimumQueryPermits;
 
         Assert.Equal(new PermitCount(16), result);
     }
@@ -67,7 +67,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void DefaultQueryPermitsReturnsExpectedResult()
     {
-        var result = AxonServerConnectionDefaults.DefaultQueryPermits;
+        var result = AxonServerConnectorDefaults.DefaultQueryPermits;
 
         Assert.Equal(new PermitCount(5_000), result);
     }
@@ -75,7 +75,7 @@ public class AxonServerConnectionFactoryDefaultsTests
     [Fact]
     public void DefaultReconnectOptions()
     {
-        var result = AxonServerConnectionDefaults.DefaultReconnectOptions;
+        var result = AxonServerConnectorDefaults.DefaultReconnectOptions;
         
         Assert.Equal(new ReconnectOptions(
             TimeSpan.FromMilliseconds(10000),

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionFactoryTests.cs
@@ -31,7 +31,7 @@ public class AxonServerConnectionFactoryTests
         var tags = _fixture.CreateMany<KeyValuePair<string, string>>(Random.Shared.Next(1, 5)).ToArray();
         var token = _fixture.Create<string>();
         var builder =
-            AxonServerConnectionFactoryOptions
+            AxonServerConnectorOptions
                 .For(component, clientInstanceId)
                 .WithRoutingServers(servers)
                 .WithClientTags(tags)

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionHeadersTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectionHeadersTests.cs
@@ -7,7 +7,7 @@ public class AxonServerConnectionHeadersTests
     [Fact]
     public void AccessTokenReturnsExpectedResult()
     {
-        var result = AxonServerConnectionHeaders.AccessToken;
+        var result = AxonServerConnectorHeaders.AccessToken;
 
         Assert.Equal("AxonIQ-Access-Token", result);
     }
@@ -15,7 +15,7 @@ public class AxonServerConnectionHeadersTests
     [Fact]
     public void ContextReturnsExpectedResult()
     {
-        var result = AxonServerConnectionHeaders.Context;
+        var result = AxonServerConnectorHeaders.Context;
 
         Assert.Equal("AxonIQ-Context", result);
     }

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectorConfigurationTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectorConfigurationTests.cs
@@ -2,12 +2,12 @@ using Xunit;
 
 namespace AxonIQ.AxonServer.Connector.Tests;
 
-public class AxonServerConnectionFactoryConfigurationTests
+public class AxonServerConnectorConfigurationTests
 {
     [Fact]
     public void DefaultSectionReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryConfiguration.DefaultSection;
+        var result = AxonServerConnectorConfiguration.DefaultSection;
 
         Assert.Equal("AxonIQ", result);
     }
@@ -15,7 +15,7 @@ public class AxonServerConnectionFactoryConfigurationTests
     [Fact]
     public void ComponentNameReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryConfiguration.ComponentName;
+        var result = AxonServerConnectorConfiguration.ComponentName;
 
         Assert.Equal("ComponentName", result);
     }
@@ -23,7 +23,7 @@ public class AxonServerConnectionFactoryConfigurationTests
     [Fact]
     public void ClientInstanceIdReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryConfiguration.ClientInstanceId;
+        var result = AxonServerConnectorConfiguration.ClientInstanceId;
 
         Assert.Equal("ClientInstanceId", result);
     }
@@ -31,7 +31,7 @@ public class AxonServerConnectionFactoryConfigurationTests
     [Fact]
     public void RoutingServersReturnsExpectedResult()
     {
-        var result = AxonServerConnectionFactoryConfiguration.RoutingServers;
+        var result = AxonServerConnectorConfiguration.RoutingServers;
 
         Assert.Equal("RoutingServers", result);
     }

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectorOptionsTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectorOptionsTests.cs
@@ -105,7 +105,7 @@ public class AxonServerConnectorOptionsTests
 
         var result = sut.Build();
 
-        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectorDefaults.RoutingServers, result.RoutingServers);
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class AxonServerConnectorOptionsTests
 
         var result = sut.Build();
 
-        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectorDefaults.RoutingServers, result.RoutingServers);
     }
 
     [Fact]
@@ -181,7 +181,7 @@ public class AxonServerConnectorOptionsTests
 
         var result = sut.Build();
 
-        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectorDefaults.RoutingServers, result.RoutingServers);
     }
 
     [Fact]
@@ -425,7 +425,7 @@ public class AxonServerConnectorOptionsTests
 
         Assert.Equal(component, result.ComponentName);
         Assert.StartsWith(result.ComponentName + "_", result.ClientInstanceId.ToString());
-        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectorDefaults.RoutingServers, result.RoutingServers);
         Assert.Empty(result.ClientTags);
         Assert.Same(AxonServerAuthentication.None, result.Authentication);
         Assert.IsType<NullLoggerFactory>(result.LoggerFactory);
@@ -457,7 +457,7 @@ public class AxonServerConnectorOptionsTests
 
         Assert.Equal(component, result.ComponentName);
         Assert.Equal(clientInstance, result.ClientInstanceId);
-        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectorDefaults.RoutingServers, result.RoutingServers);
         Assert.Empty(result.ClientTags);
         Assert.Same(AxonServerAuthentication.None, result.Authentication);
         Assert.IsType<NullLoggerFactory>(result.LoggerFactory);
@@ -575,7 +575,7 @@ public class AxonServerConnectorOptionsTests
         var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.Build();
         
-        Assert.Equal(AxonServerConnectionDefaults.DefaultReconnectOptions, result.ReconnectOptions);
+        Assert.Equal(AxonServerConnectorDefaults.DefaultReconnectOptions, result.ReconnectOptions);
     }
     
     [Fact]
@@ -598,7 +598,7 @@ public class AxonServerConnectorOptionsTests
         var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.Build();
         
-        Assert.Equal(AxonServerConnectionDefaults.DefaultEventProcessorUpdateFrequency, result.EventProcessorUpdateFrequency);
+        Assert.Equal(AxonServerConnectorDefaults.DefaultEventProcessorUpdateFrequency, result.EventProcessorUpdateFrequency);
     }
     //TODO: Extend with tests that cover obtaining all other options from configuration
     

--- a/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectorOptionsTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/AxonServerConnectorOptionsTests.cs
@@ -9,11 +9,11 @@ using Xunit;
 
 namespace AxonIQ.AxonServer.Connector.Tests;
 
-public class AxonServerConnectionFactoryOptionsTests
+public class AxonServerConnectorOptionsTests
 {
     private readonly IFixture _fixture;
 
-    public AxonServerConnectionFactoryOptionsTests()
+    public AxonServerConnectorOptionsTests()
     {
         _fixture = new Fixture();
         _fixture.CustomizeComponentName();
@@ -26,9 +26,9 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
 
-        var sut = AxonServerConnectionFactoryOptions.For(component);
+        var sut = AxonServerConnectorOptions.For(component);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -43,9 +43,9 @@ public class AxonServerConnectionFactoryOptionsTests
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -54,12 +54,12 @@ public class AxonServerConnectionFactoryOptionsTests
         Assert.Equal(clientInstance, result.ClientInstanceId);
     }
 
-    private IAxonServerConnectionFactoryOptionsBuilder CreateSystemUnderTest()
+    private IAxonServerConnectorOptionsBuilder CreateSystemUnderTest()
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        return AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        return AxonServerConnectorOptions.For(component, clientInstance);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .AsComponentName(component);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -87,7 +87,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .AsClientInstanceId(clientInstanceId);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -101,11 +101,11 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithDefaultRoutingServers();
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
-        Assert.Equal(AxonServerConnectionFactoryDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithRoutingServers(servers);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -139,11 +139,11 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithRoutingServers();
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
-        Assert.Equal(AxonServerConnectionFactoryDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithRoutingServers(servers);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -177,11 +177,11 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithRoutingServers(Enumerable.Empty<DnsEndPoint>());
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
-        Assert.Equal(AxonServerConnectionFactoryDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithoutAuthentication();
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -215,7 +215,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithAuthenticationToken(token);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -241,7 +241,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithClientTags(tags);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -264,7 +264,7 @@ public class AxonServerConnectionFactoryOptionsTests
                 .WithClientTags(writtenTags)
                 .WithClientTags(overwriteTags);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -289,7 +289,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithClientTags(tags);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -312,7 +312,7 @@ public class AxonServerConnectionFactoryOptionsTests
                 .WithClientTags(writtenTags)
                 .WithClientTags(overwriteTags);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
@@ -349,7 +349,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithClientTag(key, value);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
         var result = sut.Build();
 
         Assert.Equal(new Dictionary<string, string> { { key, value } }, result.ClientTags);
@@ -365,7 +365,7 @@ public class AxonServerConnectionFactoryOptionsTests
                 .WithClientTag(key, "1")
                 .WithClientTag(key, "2");
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
         var result = sut.Build();
 
         Assert.Equal(new Dictionary<string, string> { { key, "2" } }, result.ClientTags);
@@ -380,7 +380,7 @@ public class AxonServerConnectionFactoryOptionsTests
             CreateSystemUnderTest()
                 .WithQueryPermits(new PermitCount(value));
         
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
         var result = sut.Build();
         
         Assert.Equal(new PermitCount(expected), result.QueryPermits);
@@ -389,13 +389,13 @@ public class AxonServerConnectionFactoryOptionsTests
     [Fact]
     public void FromConfigurationCanNotBeNull()
     {
-        Assert.Throws<ArgumentNullException>(() => AxonServerConnectionFactoryOptions.FromConfiguration(null!));
+        Assert.Throws<ArgumentNullException>(() => AxonServerConnectorOptions.FromConfiguration(null!));
     }
 
     [Fact]
     public void FromConfigurationDefaultsToUnnamedComponentNameWhenComponentNameIsMissing()
     {
-        var sut = AxonServerConnectionFactoryOptions.FromConfiguration(
+        var sut = AxonServerConnectorOptions.FromConfiguration(
             new ConfigurationRoot(new List<IConfigurationProvider>()));
         var result = sut.Build();
         Assert.StartsWith(ComponentName.Default.SuffixWith("_").ToString(),
@@ -411,21 +411,21 @@ public class AxonServerConnectionFactoryOptionsTests
         {
             InitialData = new KeyValuePair<string, string>[]
             {
-                new(AxonServerConnectionFactoryConfiguration.ComponentName, component.ToString())
+                new(AxonServerConnectorConfiguration.ComponentName, component.ToString())
             }
         };
         var configuration = new ConfigurationRoot(new List<IConfigurationProvider>
             { new MemoryConfigurationProvider(source) });
 
-        var sut = AxonServerConnectionFactoryOptions.FromConfiguration(configuration);
+        var sut = AxonServerConnectorOptions.FromConfiguration(configuration);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
         Assert.Equal(component, result.ComponentName);
         Assert.StartsWith(result.ComponentName + "_", result.ClientInstanceId.ToString());
-        Assert.Equal(AxonServerConnectionFactoryDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
         Assert.Empty(result.ClientTags);
         Assert.Same(AxonServerAuthentication.None, result.Authentication);
         Assert.IsType<NullLoggerFactory>(result.LoggerFactory);
@@ -442,22 +442,22 @@ public class AxonServerConnectionFactoryOptionsTests
         {
             InitialData = new KeyValuePair<string, string>[]
             {
-                new(AxonServerConnectionFactoryConfiguration.ComponentName, component.ToString()),
-                new(AxonServerConnectionFactoryConfiguration.ClientInstanceId, clientInstance.ToString())
+                new(AxonServerConnectorConfiguration.ComponentName, component.ToString()),
+                new(AxonServerConnectorConfiguration.ClientInstanceId, clientInstance.ToString())
             }
         };
         var configuration = new ConfigurationRoot(new List<IConfigurationProvider>
             { new MemoryConfigurationProvider(source) });
 
-        var sut = AxonServerConnectionFactoryOptions.FromConfiguration(configuration);
+        var sut = AxonServerConnectorOptions.FromConfiguration(configuration);
 
-        Assert.IsAssignableFrom<IAxonServerConnectionFactoryOptionsBuilder>(sut);
+        Assert.IsAssignableFrom<IAxonServerConnectorOptionsBuilder>(sut);
 
         var result = sut.Build();
 
         Assert.Equal(component, result.ComponentName);
         Assert.Equal(clientInstance, result.ClientInstanceId);
-        Assert.Equal(AxonServerConnectionFactoryDefaults.RoutingServers, result.RoutingServers);
+        Assert.Equal(AxonServerConnectionDefaults.RoutingServers, result.RoutingServers);
         Assert.Empty(result.ClientTags);
         Assert.Same(AxonServerAuthentication.None, result.Authentication);
         Assert.IsType<NullLoggerFactory>(result.LoggerFactory);
@@ -476,7 +476,7 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var loggerFactory = new NullLoggerFactory();
         var result = sut.WithLoggerFactory(loggerFactory).Build();
         
@@ -488,7 +488,7 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.Build();
         
         Assert.IsType<NullLoggerFactory>(result.LoggerFactory);
@@ -505,7 +505,7 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var options = new GrpcChannelOptions();
         var result = sut.WithGrpcChannelOptions(options).Build();
         
@@ -517,7 +517,7 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.Build();
         
         Assert.Null(result.GrpcChannelOptions);
@@ -534,7 +534,7 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var interceptors = new Interceptor[]
         {
             new FakeInterceptor()
@@ -549,7 +549,7 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.Build();
         
         Assert.Empty(result.Interceptors);
@@ -561,7 +561,7 @@ public class AxonServerConnectionFactoryOptionsTests
         var options = _fixture.Create<ReconnectOptions>();
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.WithReconnectOptions(options).Build();
         
         Assert.Equal(options, result.ReconnectOptions);
@@ -572,10 +572,10 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.Build();
         
-        Assert.Equal(AxonServerConnectionFactoryDefaults.DefaultReconnectOptions, result.ReconnectOptions);
+        Assert.Equal(AxonServerConnectionDefaults.DefaultReconnectOptions, result.ReconnectOptions);
     }
     
     [Fact]
@@ -584,7 +584,7 @@ public class AxonServerConnectionFactoryOptionsTests
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
         var frequency = TimeSpan.FromMilliseconds(Random.Shared.Next(2000, 5000));
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.WithEventProcessorUpdateFrequency(frequency).Build();
         
         Assert.Equal(frequency, result.EventProcessorUpdateFrequency);
@@ -595,10 +595,10 @@ public class AxonServerConnectionFactoryOptionsTests
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
-        var sut = AxonServerConnectionFactoryOptions.For(component, clientInstance);
+        var sut = AxonServerConnectorOptions.For(component, clientInstance);
         var result = sut.Build();
         
-        Assert.Equal(AxonServerConnectionFactoryDefaults.DefaultEventProcessorUpdateFrequency, result.EventProcessorUpdateFrequency);
+        Assert.Equal(AxonServerConnectionDefaults.DefaultEventProcessorUpdateFrequency, result.EventProcessorUpdateFrequency);
     }
     //TODO: Extend with tests that cover obtaining all other options from configuration
     

--- a/test/AxonIQ.AxonServer.Connector.Tests/CommandNameTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/CommandNameTests.cs
@@ -1,0 +1,50 @@
+using AutoFixture;
+using AutoFixture.Idioms;
+using Xunit;
+
+namespace AxonIQ.AxonServer.Connector.Tests;
+
+public class CommandNameTests
+{
+    private readonly Fixture _fixture;
+
+    public CommandNameTests()
+    {
+        _fixture = new Fixture();
+    }
+
+    [Fact]
+    public void CanNotBeNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CommandName(null!));
+    }
+
+    [Fact]
+    public void CanNotBeEmpty()
+    {
+        Assert.Throws<ArgumentException>(() => new CommandName(string.Empty));
+    }
+
+    [Fact]
+    public void ToStringReturnsExpectedResult()
+    {
+        var value = _fixture.Create<string>();
+        var sut = new CommandName(value);
+
+        var result = sut.ToString();
+
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void VerifyEquality()
+    {
+        new CompositeIdiomaticAssertion(
+            new EqualsNullAssertion(_fixture),
+            new EqualsSelfAssertion(_fixture),
+            new EqualsSuccessiveAssertion(_fixture),
+            new EqualsNewObjectAssertion(_fixture),
+            new GetHashCodeSuccessiveAssertion(_fixture)
+        ).Verify(typeof(CommandName));
+    }
+}

--- a/test/AxonIQ.AxonServer.Connector.Tests/ContextTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/ContextTests.cs
@@ -82,7 +82,7 @@ public class ContextTests
 
         Assert.Equal(new Metadata
         {
-            { AxonServerConnectionHeaders.Context, context }
+            { AxonServerConnectorHeaders.Context, context }
         }, metadata, new MetadataEntryKeyValueComparer());
     }
 }

--- a/test/AxonIQ.AxonServer.Connector.Tests/PublicApiAssertions.VerifyApiChanges.verified.txt
+++ b/test/AxonIQ.AxonServer.Connector.Tests/PublicApiAssertions.VerifyApiChanges.verified.txt
@@ -18,20 +18,38 @@ namespace AxonIQ.AxonServer.Connector
         public static readonly AxonIQ.AxonServer.Connector.IAxonServerAuthentication None;
         public static AxonIQ.AxonServer.Connector.IAxonServerAuthentication UsingToken(string token) { }
     }
+    public class AxonServerConnection : AxonIQ.AxonServer.Connector.IAxonServerConnection, System.IAsyncDisposable
+    {
+        public AxonServerConnection(AxonIQ.AxonServer.Connector.Context context, AxonIQ.AxonServer.Connector.AxonServerConnectorOptions options) { }
+        public AxonIQ.AxonServer.Connector.IAdminChannel AdminChannel { get; }
+        public AxonIQ.AxonServer.Connector.ClientIdentity ClientIdentity { get; }
+        public AxonIQ.AxonServer.Connector.ICommandChannel CommandChannel { get; }
+        public AxonIQ.AxonServer.Connector.Context Context { get; }
+        public AxonIQ.AxonServer.Connector.IControlChannel ControlChannel { get; }
+        public AxonIQ.AxonServer.Connector.IEventChannel EventChannel { get; }
+        public bool IsClosed { get; }
+        public bool IsConnected { get; }
+        public bool IsReady { get; }
+        public AxonIQ.AxonServer.Connector.IQueryChannel QueryChannel { get; }
+        public System.Threading.Tasks.Task CloseAsync() { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { }
+        public System.Threading.Tasks.Task WaitUntilConnectedAsync() { }
+        public System.Threading.Tasks.Task WaitUntilReadyAsync() { }
+    }
     public class AxonServerConnectionFactory : System.IAsyncDisposable
     {
-        public AxonServerConnectionFactory(AxonIQ.AxonServer.Connector.AxonServerConnectionFactoryOptions options) { }
+        public AxonServerConnectionFactory(AxonIQ.AxonServer.Connector.AxonServerConnectorOptions options) { }
         public System.Threading.Tasks.Task<AxonIQ.AxonServer.Connector.IAxonServerConnection> ConnectAsync(AxonIQ.AxonServer.Connector.Context context, System.Threading.CancellationToken ct = default) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
     }
-    public static class AxonServerConnectionFactoryConfiguration
+    public static class AxonServerConnectorConfiguration
     {
         public const string ClientInstanceId = "ClientInstanceId";
         public const string ComponentName = "ComponentName";
         public const string DefaultSection = "AxonIQ";
         public const string RoutingServers = "RoutingServers";
     }
-    public static class AxonServerConnectionFactoryDefaults
+    public static class AxonServerConnectorDefaults
     {
         public static readonly AxonIQ.AxonServer.Connector.IAxonServerAuthentication Authentication;
         public static readonly System.Collections.Generic.IReadOnlyDictionary<string, string> ClientTags;
@@ -44,7 +62,12 @@ namespace AxonIQ.AxonServer.Connector
         public static readonly int Port;
         public static readonly System.Collections.Generic.IReadOnlyCollection<System.Net.DnsEndPoint> RoutingServers;
     }
-    public class AxonServerConnectionFactoryOptions
+    public static class AxonServerConnectorHeaders
+    {
+        public const string AccessToken = "AxonIQ-Access-Token";
+        public const string Context = "AxonIQ-Context";
+    }
+    public class AxonServerConnectorOptions
     {
         public AxonIQ.AxonServer.Connector.IAxonServerAuthentication Authentication { get; }
         public AxonIQ.AxonServer.Connector.ClientInstanceId ClientInstanceId { get; }
@@ -59,14 +82,9 @@ namespace AxonIQ.AxonServer.Connector
         public AxonIQ.AxonServer.Connector.PermitCount QueryPermits { get; }
         public AxonIQ.AxonServer.Connector.ReconnectOptions ReconnectOptions { get; }
         public System.Collections.Generic.IReadOnlyList<System.Net.DnsEndPoint> RoutingServers { get; }
-        public static AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder For(AxonIQ.AxonServer.Connector.ComponentName componentName) { }
-        public static AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder For(AxonIQ.AxonServer.Connector.ComponentName componentName, AxonIQ.AxonServer.Connector.ClientInstanceId clientInstanceId) { }
-        public static AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder FromConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration) { }
-    }
-    public static class AxonServerConnectionHeaders
-    {
-        public const string AccessToken = "AxonIQ-Access-Token";
-        public const string Context = "AxonIQ-Context";
+        public static AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder For(AxonIQ.AxonServer.Connector.ComponentName componentName) { }
+        public static AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder For(AxonIQ.AxonServer.Connector.ComponentName componentName, AxonIQ.AxonServer.Connector.ClientInstanceId clientInstanceId) { }
+        public static AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder FromConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration) { }
     }
     public class AxonServerException : System.Exception
     {
@@ -274,27 +292,27 @@ namespace AxonIQ.AxonServer.Connector
         System.Threading.Tasks.Task WaitUntilReadyAsync();
         System.Threading.Tasks.Task WaitUntilReadyAsync(System.TimeSpan timeout);
     }
-    public interface IAxonServerConnectionFactoryOptionsBuilder
+    public interface IAxonServerConnectorOptionsBuilder
     {
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder AsClientInstanceId(AxonIQ.AxonServer.Connector.ClientInstanceId id);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder AsComponentName(AxonIQ.AxonServer.Connector.ComponentName name);
-        AxonIQ.AxonServer.Connector.AxonServerConnectionFactoryOptions Build();
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithAuthenticationToken(string token);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithClientTag(string key, string value);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithClientTags(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> tags);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithClientTags(params System.Collections.Generic.KeyValuePair<string, string>[] tags);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithClock(System.Func<System.DateTimeOffset> clock);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithCommandPermits(AxonIQ.AxonServer.Connector.PermitCount count);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithDefaultRoutingServers();
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithEventProcessorUpdateFrequency(System.TimeSpan frequency);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithGrpcChannelOptions(Grpc.Net.Client.GrpcChannelOptions grpcChannelOptions);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithInterceptors(params Grpc.Core.Interceptors.Interceptor[] interceptors);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithQueryPermits(AxonIQ.AxonServer.Connector.PermitCount count);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithReconnectOptions(AxonIQ.AxonServer.Connector.ReconnectOptions options);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithRoutingServers(System.Collections.Generic.IEnumerable<System.Net.DnsEndPoint> servers);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithRoutingServers(params System.Net.DnsEndPoint[] servers);
-        AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder WithoutAuthentication();
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder AsClientInstanceId(AxonIQ.AxonServer.Connector.ClientInstanceId id);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder AsComponentName(AxonIQ.AxonServer.Connector.ComponentName name);
+        AxonIQ.AxonServer.Connector.AxonServerConnectorOptions Build();
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithAuthenticationToken(string token);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithClientTag(string key, string value);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithClientTags(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> tags);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithClientTags(params System.Collections.Generic.KeyValuePair<string, string>[] tags);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithClock(System.Func<System.DateTimeOffset> clock);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithCommandPermits(AxonIQ.AxonServer.Connector.PermitCount count);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithDefaultRoutingServers();
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithEventProcessorUpdateFrequency(System.TimeSpan frequency);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithGrpcChannelOptions(Grpc.Net.Client.GrpcChannelOptions grpcChannelOptions);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithInterceptors(params Grpc.Core.Interceptors.Interceptor[] interceptors);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithQueryPermits(AxonIQ.AxonServer.Connector.PermitCount count);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithReconnectOptions(AxonIQ.AxonServer.Connector.ReconnectOptions options);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithRoutingServers(System.Collections.Generic.IEnumerable<System.Net.DnsEndPoint> servers);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithRoutingServers(params System.Net.DnsEndPoint[] servers);
+        AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder WithoutAuthentication();
     }
     public interface ICommandChannel
     {
@@ -542,10 +560,14 @@ namespace AxonIQ.AxonServer.Connector
     public delegate System.Threading.Tasks.ValueTask SendHeartbeat(AxonIQ.AxonServer.Connector.ReceiveHeartbeatAcknowledgement responder, System.TimeSpan timeout);
     public static class ServiceCollectionExtensions
     {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, AxonIQ.AxonServer.Connector.Context context) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, AxonIQ.AxonServer.Connector.Context context, AxonIQ.AxonServer.Connector.AxonServerConnectorOptions options) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, AxonIQ.AxonServer.Connector.Context context, Microsoft.Extensions.Configuration.IConfiguration configuration) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, AxonIQ.AxonServer.Connector.Context context, System.Action<AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder> configure) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnectionFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnectionFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, AxonIQ.AxonServer.Connector.AxonServerConnectionFactoryOptions options) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnectionFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, AxonIQ.AxonServer.Connector.AxonServerConnectorOptions options) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnectionFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnectionFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<AxonIQ.AxonServer.Connector.IAxonServerConnectionFactoryOptionsBuilder> configure) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAxonServerConnectionFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<AxonIQ.AxonServer.Connector.IAxonServerConnectorOptionsBuilder> configure) { }
     }
     public readonly struct SubscriptionId
     {

--- a/test/AxonIQ.AxonServer.Connector.Tests/SchedulerTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/SchedulerTests.cs
@@ -1,4 +1,5 @@
 using AxonIQ.AxonServer.Connector.Tests.Framework;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,11 +13,39 @@ public class SchedulerTests
     {
         _logger = new TestOutputHelperLogger<Scheduler>(output);
     }
+
+    [Fact]
+    public void ClockCanNotBeNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Scheduler(null!, 
+                Scheduler.DefaultTickFrequency, 
+                new NullLogger<Scheduler>()));
+    }
+    
+    [Fact]
+    public void LoggerCanNotBeNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Scheduler(() => DateTimeOffset.UtcNow, 
+                Scheduler.DefaultTickFrequency, 
+                null!));
+    }
+
+    [Fact]
+    public void FrequencyCanNotBeNegative()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Scheduler(
+                () => DateTimeOffset.UtcNow,
+                TimeSpan.MinValue,
+                new NullLogger<Scheduler>()));
+    }
     
     [Fact]
     public async Task SchedulingTaskImmediatelyHasExpectedResult()
     {
-        var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5), _logger);
 
         var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await sut.ScheduleTaskAsync(() =>
@@ -29,9 +58,27 @@ public class SchedulerTests
     }
     
     [Fact]
+    public async Task SchedulingCancelledTaskHasExpectedResult()
+    {
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(100), _logger);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await sut.ScheduleTaskAsync(() =>
+        {
+            source.TrySetResult();
+            cancellation.Token.ThrowIfCancellationRequested();
+            return ValueTask.CompletedTask;
+        }, TimeSpan.FromMilliseconds(200));
+        
+        Assert.True(source.Task.Wait(TimeSpan.FromMilliseconds(300)));
+    }
+    
+    [Fact]
     public async Task SchedulingTaskHasExpectedResult()
     {
-        var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
 
         var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await sut.ScheduleTaskAsync(() =>
@@ -44,9 +91,9 @@ public class SchedulerTests
     }
 
     [Fact]
-    public async Task SchedulingCancelledTaskDoesNotInterfereWithSubsequentScheduledTasks()
+    public async Task SchedulingCancelledTaskImmediatelyDoesNotInterfereWithSubsequentScheduledTasks()
     {
-        var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
 
         var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
@@ -54,6 +101,7 @@ public class SchedulerTests
         await sut.ScheduleTaskAsync(() =>
         {
             source1.TrySetResult();
+            cancellation.Token.ThrowIfCancellationRequested();
             return ValueTask.FromCanceled(cancellation.Token);
         }, TimeSpan.Zero);
         
@@ -69,9 +117,35 @@ public class SchedulerTests
     }
     
     [Fact]
-    public async Task SchedulingExceptionalTaskDoesNotInterfereWithSubsequentScheduledTasks()
+    public async Task SchedulingCancelledTaskDoesNotInterfereWithSubsequentScheduledTasks()
     {
-        var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+
+        var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var source1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await sut.ScheduleTaskAsync(() =>
+        {
+            source1.TrySetResult();
+            cancellation.Token.ThrowIfCancellationRequested();
+            return ValueTask.FromCanceled(cancellation.Token);
+        }, TimeSpan.FromMilliseconds(50));
+        
+        Assert.True(source1.Task.Wait(TimeSpan.FromMilliseconds(100)));
+        
+        var source2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await sut.ScheduleTaskAsync(() =>
+        {
+            source2.TrySetResult();
+            return ValueTask.CompletedTask;
+        }, TimeSpan.FromMilliseconds(50));
+        Assert.True(source2.Task.Wait(TimeSpan.FromMilliseconds(100)));
+    }
+    
+    [Fact]
+    public async Task SchedulingExceptionalTaskImmediatelyDoesNotInterfereWithSubsequentScheduledTasks()
+    {
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
 
         var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
@@ -92,5 +166,47 @@ public class SchedulerTests
         }, TimeSpan.Zero);
         
         Assert.True(source2.Task.Wait(TimeSpan.FromMilliseconds(100)));
+    }
+    
+    [Fact]
+    public async Task SchedulingExceptionalTaskDoesNotInterfereWithSubsequentScheduledTasks()
+    {
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+
+        var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var source1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await sut.ScheduleTaskAsync(() =>
+        {
+            source1.TrySetResult();
+            throw new Exception();
+        }, TimeSpan.FromMilliseconds(50));
+        
+        Assert.True(source1.Task.Wait(TimeSpan.FromMilliseconds(100)));
+        
+        var source2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await sut.ScheduleTaskAsync(() =>
+        {
+            source2.TrySetResult();
+            return ValueTask.CompletedTask;
+        }, TimeSpan.FromMilliseconds(50));
+        
+        Assert.True(source2.Task.Wait(TimeSpan.FromMilliseconds(100)));
+    }
+
+    [Fact]
+    public async Task SchedulingTaskOnDisposedSchedulerHasExpectedResult()
+    {
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+        await sut.DisposeAsync();
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => sut.ScheduleTaskAsync(() => ValueTask.CompletedTask, TimeSpan.Zero).AsTask());
+    }
+
+    [Fact]
+    public async Task ClockReturnsExpectedResult()
+    {
+        var clock = () => DateTimeOffset.UtcNow;
+        await using var sut = new Scheduler(clock, TimeSpan.FromMilliseconds(50), _logger);
+        Assert.Same(clock, sut.Clock);
     }
 }

--- a/test/AxonIQ.AxonServer.Connector.Tests/SchedulerTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/SchedulerTests.cs
@@ -60,7 +60,7 @@ public class SchedulerTests
     [Fact]
     public async Task SchedulingCancelledTaskHasExpectedResult()
     {
-        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(100), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(10), _logger);
 
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
@@ -171,7 +171,7 @@ public class SchedulerTests
     [Fact]
     public async Task SchedulingExceptionalTaskDoesNotInterfereWithSubsequentScheduledTasks()
     {
-        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(10), _logger);
 
         var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/test/AxonIQ.AxonServer.Connector.Tests/SchedulerTests.cs
+++ b/test/AxonIQ.AxonServer.Connector.Tests/SchedulerTests.cs
@@ -119,7 +119,7 @@ public class SchedulerTests
     [Fact]
     public async Task SchedulingCancelledTaskDoesNotInterfereWithSubsequentScheduledTasks()
     {
-        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(10), _logger);
 
         var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
@@ -145,7 +145,7 @@ public class SchedulerTests
     [Fact]
     public async Task SchedulingExceptionalTaskImmediatelyDoesNotInterfereWithSubsequentScheduledTasks()
     {
-        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(50), _logger);
+        await using var sut = new Scheduler(() => DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(10), _logger);
 
         var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/test/AxonIQ.AxonServerIntegrationTests/AxonServerAdminChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/AxonServerAdminChannelIntegrationTests.cs
@@ -32,12 +32,12 @@ public class AxonServerAdminChannelIntegrationTests
     }
 
     private async Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);

--- a/test/AxonIQ.AxonServerIntegrationTests/AxonServerConnectionFactoryIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/AxonServerConnectionFactoryIntegrationTests.cs
@@ -23,12 +23,12 @@ public class AxonServerConnectionFactoryIntegrationTests
     }
 
     private AxonServerConnectionFactory CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint());
         configure?.Invoke(builder);
         var options = builder.Build();

--- a/test/AxonIQ.AxonServerIntegrationTests/AxonServerConnectionIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/AxonServerConnectionIntegrationTests.cs
@@ -58,7 +58,7 @@ public class AxonServerConnectionIntegrationTests
     {
         var sut = await CreateSystemUnderTest(
             options => options.WithRoutingServers(
-                new DnsEndPoint("127.0.0.0", AxonServerConnectionDefaults.Port)));
+                new DnsEndPoint("127.0.0.0", AxonServerConnectorDefaults.Port)));
         var wait = sut.WaitUntilConnectedAsync().ConfigureAwait(false);
         await sut.DisposeAsync().ConfigureAwait(false);
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await wait).ConfigureAwait(false);
@@ -69,7 +69,7 @@ public class AxonServerConnectionIntegrationTests
     {
         var sut = await CreateSystemUnderTest(
             options => options.WithRoutingServers(
-                new DnsEndPoint("127.0.0.0", AxonServerConnectionDefaults.Port)));
+                new DnsEndPoint("127.0.0.0", AxonServerConnectorDefaults.Port)));
         var wait = sut.WaitUntilReadyAsync().ConfigureAwait(false);
         await sut.DisposeAsync().ConfigureAwait(false);
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await wait).ConfigureAwait(false);

--- a/test/AxonIQ.AxonServerIntegrationTests/AxonServerConnectionIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/AxonServerConnectionIntegrationTests.cs
@@ -31,12 +31,12 @@ public class AxonServerConnectionIntegrationTests
     }
 
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint())
             .WithLoggerFactory(new TestOutputHelperLoggerFactory(_output));
         configure?.Invoke(builder);
@@ -46,7 +46,7 @@ public class AxonServerConnectionIntegrationTests
     }
 
     private async Task<IAxonServerConnection> CreateDisposedSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var sut = await CreateSystemUnderTest(configure);
         await sut.DisposeAsync().ConfigureAwait(false);
@@ -58,7 +58,7 @@ public class AxonServerConnectionIntegrationTests
     {
         var sut = await CreateSystemUnderTest(
             options => options.WithRoutingServers(
-                new DnsEndPoint("127.0.0.0", AxonServerConnectionFactoryDefaults.Port)));
+                new DnsEndPoint("127.0.0.0", AxonServerConnectionDefaults.Port)));
         var wait = sut.WaitUntilConnectedAsync().ConfigureAwait(false);
         await sut.DisposeAsync().ConfigureAwait(false);
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await wait).ConfigureAwait(false);
@@ -69,7 +69,7 @@ public class AxonServerConnectionIntegrationTests
     {
         var sut = await CreateSystemUnderTest(
             options => options.WithRoutingServers(
-                new DnsEndPoint("127.0.0.0", AxonServerConnectionFactoryDefaults.Port)));
+                new DnsEndPoint("127.0.0.0", AxonServerConnectionDefaults.Port)));
         var wait = sut.WaitUntilReadyAsync().ConfigureAwait(false);
         await sut.DisposeAsync().ConfigureAwait(false);
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await wait).ConfigureAwait(false);

--- a/test/AxonIQ.AxonServerIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
@@ -34,7 +34,7 @@ public class AxonServerGrpcChannelFactoryTests
         public async Task CreateReturnsExpectedResult()
         {
             var clock = () => DateTimeOffset.UtcNow;
-            var connectionTimeout = AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout;
+            var connectionTimeout = AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout;
             var clientIdentity = _fixture.Create<ClientIdentity>();
             var context = _fixture.Create<Context>();
             var routingServers = _fixture.CreateMany<DnsEndPoint>(Random.Shared.Next(1, 5)).ToArray();
@@ -79,7 +79,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
         
         private AxonServerGrpcChannelFactory CreateSystemUnderTest(IReadOnlyList<DnsEndPoint> routingServers, IAxonServerAuthentication authentication)
@@ -145,7 +145,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clock = () => DateTimeOffset.UtcNow;
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory, Array.Empty<Interceptor>(),
-                new GrpcChannelOptions(), clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                new GrpcChannelOptions(), clock, AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
         
         [Fact]

--- a/test/AxonIQ.AxonServerIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/AxonServerGrpcChannelFactoryTests.cs
@@ -34,7 +34,7 @@ public class AxonServerGrpcChannelFactoryTests
         public async Task CreateReturnsExpectedResult()
         {
             var clock = () => DateTimeOffset.UtcNow;
-            var connectionTimeout = AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout;
+            var connectionTimeout = AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout;
             var clientIdentity = _fixture.Create<ClientIdentity>();
             var context = _fixture.Create<Context>();
             var routingServers = _fixture.CreateMany<DnsEndPoint>(Random.Shared.Next(1, 5)).ToArray();
@@ -79,7 +79,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, AxonServerAuthentication.None,
                 routingServers, _loggerFactory, Array.Empty<Interceptor>(), new GrpcChannelOptions(),
-                clock, AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
         
         private AxonServerGrpcChannelFactory CreateSystemUnderTest(IReadOnlyList<DnsEndPoint> routingServers, IAxonServerAuthentication authentication)
@@ -145,7 +145,7 @@ public class AxonServerGrpcChannelFactoryTests
             var clock = () => DateTimeOffset.UtcNow;
             var clientIdentity = _fixture.Create<ClientIdentity>();
             return new AxonServerGrpcChannelFactory(clientIdentity, authentication, routingServers, _loggerFactory, Array.Empty<Interceptor>(),
-                new GrpcChannelOptions(), clock, AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout);
+                new GrpcChannelOptions(), clock, AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout);
         }
         
         [Fact]

--- a/test/AxonIQ.AxonServerIntegrationTests/CommandChannelConnectivityIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/CommandChannelConnectivityIntegrationTests.cs
@@ -51,7 +51,7 @@ public class CommandChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)))
             .ConfigureAwait(false);
@@ -125,7 +125,7 @@ public class CommandChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();

--- a/test/AxonIQ.AxonServerIntegrationTests/CommandChannelConnectivityIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/CommandChannelConnectivityIntegrationTests.cs
@@ -30,12 +30,12 @@ public class CommandChannelConnectivityIntegrationTests
     }
 
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcProxyEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);
@@ -51,7 +51,7 @@ public class CommandChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)))
             .ConfigureAwait(false);
@@ -125,7 +125,7 @@ public class CommandChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();

--- a/test/AxonIQ.AxonServerIntegrationTests/CommandChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/CommandChannelIntegrationTests.cs
@@ -33,12 +33,12 @@ public class CommandChannelIntegrationTests
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);

--- a/test/AxonIQ.AxonServerIntegrationTests/ControlChannelConnectivityIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/ControlChannelConnectivityIntegrationTests.cs
@@ -28,12 +28,12 @@ public class ControlChannelConnectivityIntegrationTests
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcProxyEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);
@@ -49,7 +49,7 @@ public class ControlChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -94,7 +94,7 @@ public class ControlChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();

--- a/test/AxonIQ.AxonServerIntegrationTests/ControlChannelConnectivityIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/ControlChannelConnectivityIntegrationTests.cs
@@ -49,7 +49,7 @@ public class ControlChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -94,7 +94,7 @@ public class ControlChannelConnectivityIntegrationTests
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();

--- a/test/AxonIQ.AxonServerIntegrationTests/ControlChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/ControlChannelIntegrationTests.cs
@@ -28,12 +28,12 @@ public class ControlChannelIntegrationTests
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);

--- a/test/AxonIQ.AxonServerIntegrationTests/EventChannelConnectivityIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/EventChannelConnectivityIntegrationTests.cs
@@ -84,7 +84,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -147,7 +147,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -210,7 +210,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -274,7 +274,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -343,7 +343,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -410,7 +410,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectorDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();

--- a/test/AxonIQ.AxonServerIntegrationTests/EventChannelConnectivityIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/EventChannelConnectivityIntegrationTests.cs
@@ -32,12 +32,12 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcProxyEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);
@@ -84,7 +84,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -147,7 +147,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -210,7 +210,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -274,7 +274,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -343,7 +343,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();
@@ -410,7 +410,7 @@ public class EventChannelConnectivityIntegrationTests : IAsyncLifetime
             options
                 .WithReconnectOptions(
                     new ReconnectOptions(
-                        AxonServerConnectionFactoryDefaults.DefaultReconnectOptions.ConnectionTimeout, 
+                        AxonServerConnectionDefaults.DefaultReconnectOptions.ConnectionTimeout, 
                         TimeSpan.FromMilliseconds(100),
                         false)));
         await connection.WaitUntilReadyAsync();

--- a/test/AxonIQ.AxonServerIntegrationTests/EventChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/EventChannelIntegrationTests.cs
@@ -31,12 +31,12 @@ public class EventChannelIntegrationTests : IAsyncLifetime
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);

--- a/test/AxonIQ.AxonServerIntegrationTests/EventProcessorIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/EventProcessorIntegrationTests.cs
@@ -32,12 +32,12 @@ public class EventProcessorIntegrationTests
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);

--- a/test/AxonIQ.AxonServerIntegrationTests/QueryChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/QueryChannelIntegrationTests.cs
@@ -49,7 +49,7 @@ public class QueryChannelIntegrationTests
     public async Task RegisterQueryHandlerWhileDisconnectedHasExpectedResult()
     {
         await using var connection = await CreateSystemUnderTest(builder =>
-            builder.WithRoutingServers(new DnsEndPoint("127.0.0.0", AxonServerConnectionDefaults.Port)));
+            builder.WithRoutingServers(new DnsEndPoint("127.0.0.0", AxonServerConnectorDefaults.Port)));
         var sut = connection.QueryChannel;
 
         var queries = new[]

--- a/test/AxonIQ.AxonServerIntegrationTests/QueryChannelIntegrationTests.cs
+++ b/test/AxonIQ.AxonServerIntegrationTests/QueryChannelIntegrationTests.cs
@@ -31,12 +31,12 @@ public class QueryChannelIntegrationTests
     }
     
     private Task<IAxonServerConnection> CreateSystemUnderTest(
-        Action<IAxonServerConnectionFactoryOptionsBuilder>? configure = default)
+        Action<IAxonServerConnectorOptionsBuilder>? configure = default)
     {
         var component = _fixture.Create<ComponentName>();
         var clientInstance = _fixture.Create<ClientInstanceId>();
 
-        var builder = AxonServerConnectionFactoryOptions.For(component, clientInstance)
+        var builder = AxonServerConnectorOptions.For(component, clientInstance)
             .WithRoutingServers(_container.GetGrpcEndpoint())
             .WithLoggerFactory(_loggerFactory);
         configure?.Invoke(builder);
@@ -49,7 +49,7 @@ public class QueryChannelIntegrationTests
     public async Task RegisterQueryHandlerWhileDisconnectedHasExpectedResult()
     {
         await using var connection = await CreateSystemUnderTest(builder =>
-            builder.WithRoutingServers(new DnsEndPoint("127.0.0.0", AxonServerConnectionFactoryDefaults.Port)));
+            builder.WithRoutingServers(new DnsEndPoint("127.0.0.0", AxonServerConnectionDefaults.Port)));
         var sut = connection.QueryChannel;
 
         var queries = new[]


### PR DESCRIPTION
This PR introduces the concept of a stand-alone `AxonServerConnection`, meaning, you do not need to go thru the `AxonServerConnectionFactory` to obtain one. It eases those scenarios where you only ever access one context, you want to register the connection in the inversion of control container (there are extra convenience methods hanging off ServiceCollection), and you want it to "auto-connect" upon accessing its API.